### PR TITLE
Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: doc/source/requirements.txt

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,6 +29,8 @@ release = '0.1'
 
 # -- General configuration ---------------------------------------------------
 
+master_doc = 'index'
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,0 +1,1 @@
+astropy-sphinx-theme


### PR DESCRIPTION
This has all the configuration needed to build on readthedocs.io.  As an example, the docs for this branch are built at https://enrico-docs.readthedocs.io/en/readthedocs/.  Once this is merged into master, I'll set up readthedocs so it builds for the master branch instead of this one.  