### PR TITLE
Consistent class naming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ set(SOURCES
 if (SCALE_FOUND)
     list(APPEND SOURCES
         src/smrt/Assembly_Model.cpp
-        src/smrt/Coupled_Solver.cpp
+        src/smrt/shift_nek_driver.cpp
         src/smrt/Multiphysics_Driver.cpp
         src/smrt/Multi_Pin_Conduction.cpp
         src/smrt/Multi_Pin_Subchannel.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if (SCALE_FOUND)
         src/smrt/Multiphysics_Driver.cpp
         src/smrt/Multi_Pin_Conduction.cpp
         src/smrt/Multi_Pin_Subchannel.cpp
-        src/smrt/Shift_Solver.cpp
+        src/smrt/shift_driver.cpp
         src/smrt/Single_Pin_Conduction.cpp
         src/smrt/Single_Pin_Subchannel.cpp
         src/smrt/Two_Group_Cross_Sections.cpp

--- a/include/smrt/shift_driver.h
+++ b/include/smrt/shift_driver.h
@@ -1,5 +1,5 @@
-#ifndef Shift_Solver_h
-#define Shift_Solver_h
+#ifndef SHIFT_DRIVER_H
+#define SHIFT_DRIVER_H
 
 #include <memory>
 #include <vector>
@@ -16,17 +16,17 @@ namespace enrico {
 
 //===========================================================================//
 /*!
- * \class Shift_Solver
+ * \class ShiftDriver
  * \brief Neutronics solver running Shift problem
  */
 /*!
  * \example shift/test/tstShift_Solver.cc
  *
- * Test of Shift_Solver.
+ * Test of ShiftDriver.
  */
 //===========================================================================//
 
-class Shift_Solver : public Neutronics_Solver {
+class ShiftDriver : public Neutronics_Solver {
 public:
   //@{
   //! Public type aliases
@@ -47,7 +47,6 @@ private:
   SP_Omn_Driver d_driver;
 
   std::vector<double> d_z_edges;
-  double d_power_norm;
   std::string d_power_tally_name;
 
   // Matids corresponding to T/H mesh elements
@@ -63,7 +62,7 @@ private:
 
 public:
   // Constructor
-  Shift_Solver(SP_Assembly_Model assembly,
+  ShiftDriver(SP_Assembly_Model assembly,
                std::string shift_input,
                const std::vector<double>& z_edges);
 
@@ -85,8 +84,8 @@ private:
 } // end namespace enrico
 
 //---------------------------------------------------------------------------//
-#endif // Shift_Solver_h
+#endif // SHIFT_DRIVER_H
 
 //---------------------------------------------------------------------------//
-// end of Shift_Solver.h
+// end of shift_driver.h
 //---------------------------------------------------------------------------//

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -24,6 +24,13 @@ namespace enrico {
  */
 //===========================================================================//
 class ShiftNekDriver {
+public:
+  //! Power in [W]
+  double power_;
+
+  //! Maximum number of Picard iterations
+  int max_picard_iter_;
+
 private:
   //
   // Data
@@ -47,16 +54,12 @@ private:
   std::vector<double> d_densities;
   std::vector<double> d_powers;
 
-  // Normalization factor for power (average
-  double d_power_norm;
 
 public:
   // Constructor
   ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
                  const std::vector<double>& z_edges,
                  const std::string& shift_filename,
-                 const std::string& enrico_filename,
-                 double power_norm,
                  MPI_Comm neutronics_comm,
                  MPI_Comm th_comm);
 

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -7,7 +7,7 @@
 #include "Nemesis/comm/global.hh"
 
 #include "Assembly_Model.h"
-#include "Shift_Solver.h"
+#include "shift_driver.h"
 #include "enrico/error.h"
 #include "enrico/message_passing.h"
 #include "enrico/nek_driver.h"
@@ -30,7 +30,7 @@ private:
   //
 
   // Shift solver
-  std::shared_ptr<Shift_Solver> d_shift_solver;
+  std::shared_ptr<ShiftDriver> d_shift_solver;
 
   // Nek solver
   std::shared_ptr<NekDriver> d_nek_solver;

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -1,6 +1,5 @@
-
-#ifndef Coupled_Solver_h
-#define Coupled_Solver_h
+#ifndef SHIFT_NEK_DRIVER_H
+#define SHIFT_NEK_DRIVER_H
 
 #include <memory>
 #include <vector>
@@ -17,14 +16,14 @@
 namespace enrico {
 //===========================================================================//
 /*!
- * \class Coupled_Solver
- * \brief Class for coupling a neutronics solver with a TH solver.
+ * \class ShiftNekDriver
+ * \brief Class for coupling Shift and Nek.
  *
  * This class will perform dampled Picard iteration to converge the
  * coupled nonlinear system.
  */
 //===========================================================================//
-class Coupled_Solver {
+class ShiftNekDriver {
 private:
   //
   // Data
@@ -53,7 +52,7 @@ private:
 
 public:
   // Constructor
-  Coupled_Solver(std::shared_ptr<Assembly_Model> assembly,
+  ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
                  const std::vector<double>& z_edges,
                  const std::string& shift_filename,
                  const std::string& enrico_filename,
@@ -62,7 +61,7 @@ public:
                  MPI_Comm th_comm);
 
   // Destructor
-  ~Coupled_Solver();
+  ~ShiftNekDriver();
 
   // Solve coupled problem
   void solve();
@@ -100,4 +99,4 @@ private:
 
 } // end namespace enrico
 
-#endif // Coupled_Solver_h
+#endif // SHIFT_NEK_DRIVER_H

--- a/src/smrt/Multiphysics_Driver.cpp
+++ b/src/smrt/Multiphysics_Driver.cpp
@@ -17,7 +17,7 @@
 #include "Omnibus/config.h"
 #include "smrt/Two_Group_Diffusion.h"
 #ifdef USE_SHIFT
-#include "smrt/Shift_Solver.h"
+#include "smrt/shift_driver.h"
 #endif
 
 namespace enrico {
@@ -78,7 +78,7 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
              "Neutronics type set to 'shift', "
              "but no 'shift_input' specified.");
     auto shift_input = neutronics_params->get<std::string>("shift_input");
-    d_neutronics = std::make_shared<Shift_Solver>(assembly, shift_input, z_edges);
+    d_neutronics = std::make_shared<ShiftDriver>(assembly, shift_input, z_edges);
 #else
     Validate(false,
              "Neutronics type set to 'shift', but Shift is not "

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -1,16 +1,16 @@
 //---------------------------------*-C++-*-----------------------------------//
 /*!
- * \file   Shift_Solver.cpp
+ * \file   shift_driver.cpp
  * \author Steven Hamilton
  * \date   Wed Aug 15 09:25:43 2018
- * \brief  Shift_Solver class definitions.
+ * \brief  ShiftDriver class definitions.
  * \note   Copyright (c) 2018 Oak Ridge National Laboratory, UT-Battelle, LLC.
  */
 //---------------------------------------------------------------------------//
 
 #include <map>
 
-#include "smrt/Shift_Solver.h"
+#include "smrt/shift_driver.h"
 
 #include "Teuchos_DefaultComm.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
@@ -24,7 +24,7 @@ namespace enrico {
 //---------------------------------------------------------------------------//
 // Constructor
 //---------------------------------------------------------------------------//
-Shift_Solver::Shift_Solver(SP_Assembly_Model assembly,
+ShiftDriver::ShiftDriver(SP_Assembly_Model assembly,
                            std::string shift_input,
                            const std::vector<double>& z_edges)
   : d_assembly(assembly)
@@ -62,7 +62,7 @@ Shift_Solver::Shift_Solver(SP_Assembly_Model assembly,
 //---------------------------------------------------------------------------//
 // Solve
 //---------------------------------------------------------------------------//
-void Shift_Solver::solve(const std::vector<double>& th_temperature,
+void ShiftDriver::solve(const std::vector<double>& th_temperature,
                          const std::vector<double>& coolant_density,
                          std::vector<double>& power)
 {
@@ -119,7 +119,7 @@ void Shift_Solver::solve(const std::vector<double>& th_temperature,
 //---------------------------------------------------------------------------//
 // Register list of centroids and cell volumes from T/H solver
 //---------------------------------------------------------------------------//
-void Shift_Solver::set_centroids_and_volumes(
+void ShiftDriver::set_centroids_and_volumes(
   const std::vector<enrico::Position>& centroids,
   const std::vector<double>& volumes)
 {
@@ -169,7 +169,7 @@ void Shift_Solver::set_centroids_and_volumes(
 //---------------------------------------------------------------------------//
 // Add power (fission rate) tally to shift problem
 //---------------------------------------------------------------------------//
-void Shift_Solver::add_power_tally(RCP_PL& pl, const std::vector<double>& z_edges)
+void ShiftDriver::add_power_tally(RCP_PL& pl, const std::vector<double>& z_edges)
 {
   Require(d_assembly);
   auto tally_pl = Teuchos::sublist(pl, "TALLY");
@@ -239,5 +239,5 @@ void Shift_Solver::add_power_tally(RCP_PL& pl, const std::vector<double>& z_edge
 } // end namespace enrico
 
 //---------------------------------------------------------------------------//
-// end of Shift_Solver.cpp
+// end of shift_driver.cpp
 //---------------------------------------------------------------------------//

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -18,7 +18,7 @@ ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
   : d_power_norm(power_norm)
 {
   d_shift_solver =
-    std::make_shared<enrico::Shift_Solver>(assembly, shift_filename, z_edges);
+    std::make_shared<enrico::ShiftDriver>(assembly, shift_filename, z_edges);
 
   // Build Nek driver
   {

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -1,15 +1,14 @@
-
 #include <iostream>
 
 #include "enrico/error.h"
 #include "enrico/nek_driver.h"
 #include "nek5000/core/nek_interface.h"
-#include "smrt/Coupled_Solver.h"
+#include "smrt/shift_nek_driver.h"
 
 namespace enrico {
 
 // Constructor
-Coupled_Solver::Coupled_Solver(std::shared_ptr<Assembly_Model> assembly,
+ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
                                const std::vector<double>& z_edges,
                                const std::string& shift_filename,
                                const std::string& enrico_filename,
@@ -87,10 +86,10 @@ Coupled_Solver::Coupled_Solver(std::shared_ptr<Assembly_Model> assembly,
 }
 
 // Destructor
-Coupled_Solver::~Coupled_Solver() {}
+ShiftNekDriver::~ShiftNekDriver() {}
 
 // Solve coupled problem by iterating between neutronics and T/H
-void Coupled_Solver::solve()
+void ShiftNekDriver::solve()
 {
   // Loop to convergence or fixed iteration count
   for (int iteration = 0; iteration < 3; ++iteration) {
@@ -146,7 +145,7 @@ void Coupled_Solver::solve()
 //
 
 // Apply power normalization
-void Coupled_Solver::normalize_power()
+void ShiftNekDriver::normalize_power()
 {
   double total_power = 0.0;
   for (int elem = 0; elem < d_th_num_local; ++elem) {
@@ -162,7 +161,7 @@ void Coupled_Solver::normalize_power()
 
 // Set up MPI datatype
 // Currently, this sets up only position_mpi_datatype
-void Coupled_Solver::init_mpi_datatypes()
+void ShiftNekDriver::init_mpi_datatypes()
 {
   Position p;
   int blockcounts[3] = {1, 1, 1};
@@ -185,26 +184,26 @@ void Coupled_Solver::init_mpi_datatypes()
 }
 
 // Free user-defined MPI types
-void Coupled_Solver::free_mpi_datatypes()
+void ShiftNekDriver::free_mpi_datatypes()
 {
   MPI_Type_free(&d_position_mpi_type);
 }
 
 // Traits for mapping plain types to corresponding MPI types
 template<>
-MPI_Datatype Coupled_Solver::get_mpi_type<double>() const
+MPI_Datatype ShiftNekDriver::get_mpi_type<double>() const
 {
   return MPI_DOUBLE;
 }
 template<>
-MPI_Datatype Coupled_Solver::get_mpi_type<Position>() const
+MPI_Datatype ShiftNekDriver::get_mpi_type<Position>() const
 {
   return d_position_mpi_type;
 }
 
 // Gather local distributed field into global replicated field
 template<typename T>
-std::vector<T> Coupled_Solver::local_to_global(const std::vector<T>& local_field) const
+std::vector<T> ShiftNekDriver::local_to_global(const std::vector<T>& local_field) const
 {
   assert(local_field.size() == d_th_num_local);
   const auto& th_comm = d_nek_solver->comm_;
@@ -226,7 +225,7 @@ std::vector<T> Coupled_Solver::local_to_global(const std::vector<T>& local_field
 
 // Scatter global replicated field into local distributed field
 template<typename T>
-std::vector<T> Coupled_Solver::global_to_local(const std::vector<T>& global_field) const
+std::vector<T> ShiftNekDriver::global_to_local(const std::vector<T>& global_field) const
 {
   const auto& th_comm = d_nek_solver->comm_;
 

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -11,26 +11,27 @@ namespace enrico {
 ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
                                const std::vector<double>& z_edges,
                                const std::string& shift_filename,
-                               const std::string& enrico_filename,
-                               double power_norm,
                                MPI_Comm neutronics_comm,
                                MPI_Comm th_comm)
-  : d_power_norm(power_norm)
 {
   d_shift_solver =
     std::make_shared<enrico::ShiftDriver>(assembly, shift_filename, z_edges);
 
   // Build Nek driver
   {
-    // Parse enrico xml file
+    // TODO: Belongs to main.cpp
     pugi::xml_document doc;
-    auto result = doc.load_file(enrico_filename.c_str());
+    auto result = doc.load_file("enrico.xml");
     if (!result) {
       throw std::runtime_error{"Unable to load enrico.xml file"};
     }
 
     // Get root element
     auto root = doc.document_element();
+
+    // TODO: Belongs to CoupledDriver base class
+    power_ = root.child("power").text().as_double();
+    max_picard_iter_ = root.child("max_picard_iter").text().as_int();
 
     d_nek_solver = std::make_shared<NekDriver>(th_comm, root.child("nek5000"));
   }
@@ -43,7 +44,7 @@ ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
   // Allocate fields (on global T/H mesh for now)
   d_temperatures.resize(d_th_num_local, 565.0);
   d_densities.resize(d_th_num_local, 0.75);
-  d_powers.resize(d_th_num_local, power_norm);
+  d_powers.resize(d_th_num_local, power_);
 
   std::vector<Position> local_centroids(d_th_num_local);
   std::vector<double> local_volumes(d_th_num_local);
@@ -92,7 +93,7 @@ ShiftNekDriver::~ShiftNekDriver() {}
 void ShiftNekDriver::solve()
 {
   // Loop to convergence or fixed iteration count
-  for (int iteration = 0; iteration < 3; ++iteration) {
+  for (int iteration = 0; iteration < max_picard_iter_; ++iteration) {
     // Set heat source in Nek
     for (int elem = 0; elem < d_th_num_local; ++elem) {
       err_chk(nek_set_heat_source(elem + 1, d_powers[elem]),
@@ -154,7 +155,7 @@ void ShiftNekDriver::normalize_power()
   nemesis::global_sum(total_power);
 
   // Apply normalization factor
-  double norm_factor = d_power_norm / total_power;
+  double norm_factor = power_ / total_power;
   for (auto& val : d_powers)
     val *= norm_factor;
 }

--- a/tests/singlerod/short/test_shift_coupled.cpp
+++ b/tests/singlerod/short/test_shift_coupled.cpp
@@ -14,7 +14,6 @@ int main(int argc, char *argv[]) {
 
   {
   std::string shift_filename  = "singlerod_short.inp.xml";
-  std::string enrico_filename = "enrico.xml";
 
   // Build assembly model
   std::vector<double> x_edges = {-0.63, 0.63};
@@ -32,13 +31,10 @@ int main(int argc, char *argv[]) {
   assembly->set_clad_radius(0.475);
   assembly->set_guide_radius(0.61214);
 
-  double power_norm = 1800.0;
   auto coupled_solver = std::make_shared<enrico::ShiftNekDriver>(
       assembly,
       z_edges,
       shift_filename,
-      enrico_filename,
-      power_norm,
       MPI_COMM_WORLD,
       MPI_COMM_WORLD);
 

--- a/tests/singlerod/short/test_shift_coupled.cpp
+++ b/tests/singlerod/short/test_shift_coupled.cpp
@@ -3,7 +3,7 @@
 
 #include "Nemesis/comm/global.hh"
 #include "smrt/Assembly_Model.h"
-#include "smrt/Coupled_Solver.h"
+#include "smrt/shift_nek_driver.h"
 #include <mpi.h>
 
 using AM = enrico::Assembly_Model;
@@ -33,7 +33,7 @@ int main(int argc, char *argv[]) {
   assembly->set_guide_radius(0.61214);
 
   double power_norm = 1800.0;
-  auto coupled_solver = std::make_shared<enrico::Coupled_Solver>(
+  auto coupled_solver = std::make_shared<enrico::ShiftNekDriver>(
       assembly,
       z_edges,
       shift_filename,


### PR DESCRIPTION
Moving !94 from gitlab originally submitted by @aprilnovak:

This PR adds consistent class naming for the Shift-related drivers (based on the conventions used on the OpenMC side of things, but either way is fine).

Also, I made a few minor changes in `ShiftNekDriver` to begin the base class consolidation process, such as always assuming that the coupling input file is named `enrico.xml` and making available `power_` and `max_timesteps_` member variables that will later be moved from `ShiftNekDriver` to `CoupledDriver`.

Since I don't have SCALE yet I couldn't compile this, but finger's crossed I didn't make any mistakes.