### PR TITLE
Removed nonexistent (hence unneeded) include dir from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ include_directories(
     include/
     vendor/iapws/include
     vendor/openmc/include
-    vendor/nek5000/3rd_party/gslib/gslib-1.0.1/src
     vendor
     src/
     ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
This dates back to when gslib was a subtree instead of a submodule.  