### PR TITLE
HeadFluidsDriver base class

### DIFF
--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -19,6 +19,8 @@ public:
 
   virtual xt::xtensor<double, 1> density() const = 0;
 
+  virtual xt::xtensor<int, 1> fluid_mask() const = 0;
+
   virtual ~HeatFluidsDriver() = default;
 };
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -15,12 +15,16 @@ public:
 
   double pressure_;  //! System pressure in [MPa]
 
-  //! Get the temperature in each element
-  //! \return Temperature in each element as [K]
+  //! Get the temperature in each region
+  //! \return Temperature in each region as [K]
   virtual xt::xtensor<double, 1> temperature() const = 0;
 
+  //! Get the density in each region
+  //! \return Temperature in each region as [g/cm^3]
   virtual xt::xtensor<double, 1> density() const = 0;
 
+  //! States whether each region is in fluid
+  //! \return For each region, 1 if region is in fluid and 0 otherwise
   virtual xt::xtensor<int, 1> fluid_mask() const = 0;
 
   virtual ~HeatFluidsDriver() = default;

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -16,6 +16,10 @@ public:
   //! Get the temperature in each element
   //! \return Temperature in each element as [K]
   virtual xt::xtensor<double, 1> temperature() const = 0;
+
+  virtual xt::xtensor<double, 1> density() const = 0;
+
+  virtual ~HeatFluidsDriver() = default;
 };
 
 } // namespace enrico

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -11,7 +11,9 @@ namespace enrico {
 //! Base class for driver that controls a heat-fluids solve
 class HeatFluidsDriver : public Driver {
 public:
-  explicit HeatFluidsDriver(MPI_Comm comm) : Driver(comm){};
+  explicit HeatFluidsDriver(MPI_Comm comm, double pressure) : Driver(comm), pressure_(pressure){};
+
+  double pressure_;  //! System pressure in [MPa]
 
   //! Get the temperature in each element
   //! \return Temperature in each element as [K]

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -32,6 +32,10 @@ public:
   //! A wrapper for the nek_end() routine in Nek5000.
   ~NekDriver();
 
+  //! Initializes a trivial runtime datafile for Nek5000.
+  //!
+  //! Nek5000 must read a file with the casename and working directory. It reads this file instead
+  //! of reading command-line arguments or otherwise inferring the working directory.
   void init_session_name();
 
   //! Runs all timesteps for a heat/fluid solve in Nek5000.

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -47,7 +47,7 @@ public:
 
   xt::xtensor<double, 1> density() const final;
 
-  xt::xtensor<int, 1> fluid_mask() const;
+  xt::xtensor<int, 1> fluid_mask() const final;
 
   //! Get the coordinate of a local element's centroid.
   //!

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -3,7 +3,7 @@
 #ifndef ENRICO_NEK_DRIVER_H
 #define ENRICO_NEK_DRIVER_H
 
-#include "driver.h"
+#include "heat_fluids_driver.h"
 #include "geom.h"
 #include "mpi.h"
 
@@ -16,7 +16,7 @@
 namespace enrico {
 
 //! Driver to initialze and run Nek5000 in stages.
-class NekDriver : public Driver {
+class NekDriver : public HeatFluidsDriver {
 public:
   //! Initializes Nek5000 with the given MPI communicator.
   //!
@@ -40,16 +40,14 @@ public:
   //! initialization and finalization for each step.
   void solve_step() final;
 
-  xt::xtensor<double, 1> temperature() const;
+  // TODO:  Unitialized!
+  double pressure_;   //!< System pressure in [MPa]
 
-  //! Get the coordinate of a global element's centroid.
-  //!
-  //! The coordinate is dimensionless.  Its units depend on the unit system used that was
-  //! used to setup the Nek problem. The user must handle any necessary conversions.
-  //!
-  //! \param global_elem The global index of the desired element
-  //! \return The dimensionless coordinate of the element's centroid
-  Position get_global_elem_centroid(int global_elem) const;
+  xt::xtensor<double, 1> temperature() const final;
+
+  xt::xtensor<double, 1> density() const final;
+
+  xt::xtensor<int, 1> fluid_mask() const;
 
   //! Get the coordinate of a local element's centroid.
   //!
@@ -58,7 +56,7 @@ public:
   //!
   //! \param local_elem The local index of the desired element
   //! \return The dimensionless coordinate of the element's centroid
-  Position get_local_elem_centroid(int local_elem) const;
+  Position centroid(int local_elem) const;
 
   //! Get the volume of a local element
   //!
@@ -67,7 +65,7 @@ public:
   //!
   //! \param local_elem The local index of the desired element
   //! \return The dimensionless Volume of the element
-  double get_local_elem_volume(int local_elem) const;
+  double volume(int local_elem) const;
 
   //! Get the volume-averaged temperature of a local element
   //!
@@ -77,23 +75,12 @@ public:
   //!
   //! \param local_elem A local element ID
   //! \return The volume-averaged temperature of the element
-  double get_local_elem_temperature(int local_elem) const;
-
-  //! Return true if a global element is in a given MPI rank
-  //! \param A global element ID
-  //! \param An MPI rank
-  //! \return True if the global element ID is in the given rank
-  bool global_elem_is_in_rank(int global_elem) const;
-
-  //! Return true if a global element is in the fluid region
-  //! \param global_elem  A global element ID
-  //! \return 1 if the global element is in fluid; 0 otherwise
-  int global_elem_is_in_fluid(int global_elem) const;
+  double temperature(int local_elem) const;
 
   //! Return true if a local element is in the fluid region
   //! \param local_elem  A local element ID
   //! \return 1 if the local element is in fluid; 0 otherwise
-  int local_elem_is_in_fluid(int local_elem) const;
+  int is_in_fluid(int local_elem) const;
 
   //! Set the heat source for a given local element
   //!

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -25,7 +25,7 @@ public:
   //! NekDriver.
   //!
   //! \param comm  The MPI communicator used to initialze Nek5000
-  explicit NekDriver(MPI_Comm comm, pugi::xml_node xml_root);
+  explicit NekDriver(MPI_Comm comm, double pressure, pugi::xml_node xml_root);
 
   //! Finalizes Nek5000.
   //!
@@ -39,9 +39,6 @@ public:
   //! A wraper for the nek_solve() routine in libnek5000.  This includes the necessary
   //! initialization and finalization for each step.
   void solve_step() final;
-
-  // TODO:  Unitialized!
-  double pressure_;   //!< System pressure in [MPa]
 
   xt::xtensor<double, 1> temperature() const final;
 

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -50,20 +50,31 @@ public:
   std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
   std::unique_ptr<NekDriver> nek_driver_;       //!< The Nek5000 driver
   double pressure_;                             //!< System pressure in [MPa]
-  int openmc_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in OpenMC
-                              //!< comm
+  int openmc_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in OpenMC comm
 
 protected:
-  //! Initialize global temperature buffers for OpenMC ranks. These arrays store
-  //! the dimensionless temperatures of Nek's global elements. These are **not**
+  //! Initialize global temperature buffers on all OpenMC ranks.
+  //!
+  //! These arrays store the dimensionless temperatures of Nek's global elements. These are **not**
   //! ordered by Nek's global element indices. Rather, these are ordered according
   //! to an MPI_Gatherv operation on Nek5000's local elements.
   void init_temperatures() override;
 
+  //! Initialize global source buffers on all OpenMC ranks.
+  //!
+  //! These arrays store the dimensionless source of Nek's global elements. These are **not**
+  //! ordered by Nek's global element indices. Rather, these are ordered according
+  //! to an MPI_Gatherv operation on Nek5000's local elements.
   void init_heat_source() override;
 
+  //! Initialize global fluid masks on all OpenMC ranks.
+  //!
+  //! These arrays store the dimensionless source of Nek's global elements. These are **not**
+  //! ordered by Nek's global element indices. Rather, these are ordered according
+  //! to an MPI_Gatherv operation on Nek5000's local elements.
   void init_elem_fluid_mask();
 
+  //! Initialize fluid masks for OpenMC cells on all OpenMC ranks.
   void init_cell_fluid_mask();
 
 private:
@@ -86,8 +97,10 @@ private:
   //! Frees the MPI datatypes (currently, only position_mpi_datatype)
   void free_mpi_datatypes();
 
+  //! Updates elem_densities_ from Nek5000's density data
   void update_elem_densities();
 
+  //! Updates cell_densities_ from elem_densities_.
   void update_cell_densities();
 
   //! MPI datatype for sending/receiving Position objects.
@@ -103,6 +116,7 @@ private:
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
   xt::xtensor<int, 1> elem_fluid_mask_;
 
+  //! States whether an OpenMC cell in the fluid region
   xt::xtensor<int, 1> cell_fluid_mask_;
 
   //! The dimensionless volumes of Nek's global elements

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -62,6 +62,10 @@ protected:
 
   void init_heat_source() override;
 
+  void init_elem_fluid_mask();
+
+  void init_cell_fluid_mask();
+
 private:
   //! Initialize MPI datatypes (currently, only position_mpi_datatype)
   void init_mpi_datatypes();
@@ -77,10 +81,14 @@ private:
 
   //! Allocate space for the global volume buffers in OpenMC ranks
   //! Currently, the density values are uninitialized.
-  void init_densities();
+  void init_elem_densities();
 
   //! Frees the MPI datatypes (currently, only position_mpi_datatype)
   void free_mpi_datatypes();
+
+  void update_elem_densities();
+
+  void update_cell_densities();
 
   //! MPI datatype for sending/receiving Position objects.
   MPI_Datatype position_mpi_datatype;
@@ -93,7 +101,9 @@ private:
   //! States whether a global element is in the fluid region
   //! These are **not** ordered by Nek's global element indices.  Rather, these are
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
-  std::vector<int> elem_is_in_fluid_;
+  xt::xtensor<int, 1> elem_fluid_mask_;
+
+  xt::xtensor<int, 1> cell_fluid_mask_;
 
   //! The dimensionless volumes of Nek's global elements
   //! These are **not** ordered by Nek's global element indices.  Rather, these are

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -25,8 +25,7 @@ public:
   //! Solves the heat-fluids surrogate solver
   void solve_step() final;
 
-  //! Number of rings in fuel and clad
-  //! \return Number of rings
+  //! Returns Number of rings in fuel and clad
   std::size_t n_rings() { return n_fuel_rings_ + n_clad_rings_; }
 
   //! Write data to VTK
@@ -38,6 +37,7 @@ public:
 
   xt::xtensor<int, 1> fluid_mask() const final;
 
+  //! Returns temperature in [K] for given region
   double temperature(int pin, int axial, int ring) const;
 
   // Data on fuel pins
@@ -75,8 +75,12 @@ private:
   //!< temperature in [K] for each (axial segment, ring)
   xt::xtensor<double, 3> temperature_;
 
+  //!< density in [g/cm^3] for each (axial segment, ring)
   xt::xtensor<double, 3> density_;
 
+  //! Value is 1 if (axial segment, ring) region is in fluid; otherwise 0
+  //!
+  //! Because the surrogate only solves heat and only represents solid, this whole xtensor == 0
   xt::xtensor<int, 3> fluid_mask_;
 
 }; // end SurrogateHeatDriver

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -3,7 +3,7 @@
 #ifndef ENRICO_SURROGATE_HEAT_DRIVER_H
 #define ENRICO_SURROGATE_HEAT_DRIVER_H
 
-#include "driver.h"
+#include "enrico/heat_fluids_driver.h"
 
 #include "pugixml.hpp"
 #include "xtensor/xtensor.hpp"
@@ -14,7 +14,7 @@
 
 namespace enrico {
 
-class SurrogateHeatDriver : public Driver {
+class SurrogateHeatDriver : public HeatFluidsDriver {
 public:
   //! Initializes heat-fluids surrogate with the given MPI communicator.
   //!
@@ -32,7 +32,9 @@ public:
   //! Write data to VTK
   void write_step(int timestep, int iteration) final;
 
-  xt::xtensor<double, 1> temperature() const;
+  xt::xtensor<double, 1> temperature() const final;
+
+  xt::xtensor<double, 1> density() const final;
 
   double temperature(int pin, int axial, int ring) const;
 
@@ -70,6 +72,8 @@ private:
 
   //!< temperature in [K] for each (axial segment, ring)
   xt::xtensor<double, 3> temperature_;
+
+  xt::xtensor<double, 3> density_;
 
 }; // end SurrogateHeatDriver
 

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -20,7 +20,7 @@ public:
   //!
   //! \param comm  The MPI communicator used to initialze the surrogate
   //! \param node  XML node containing settings for surrogate
-  explicit SurrogateHeatDriver(MPI_Comm comm, pugi::xml_node node);
+  explicit SurrogateHeatDriver(MPI_Comm comm, double pressure, pugi::xml_node node);
 
   //! Solves the heat-fluids surrogate solver
   void solve_step() final;

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -36,6 +36,8 @@ public:
 
   xt::xtensor<double, 1> density() const final;
 
+  xt::xtensor<int, 1> fluid_mask() const final;
+
   double temperature(int pin, int axial, int ring) const;
 
   // Data on fuel pins
@@ -74,6 +76,8 @@ private:
   xt::xtensor<double, 3> temperature_;
 
   xt::xtensor<double, 3> density_;
+
+  xt::xtensor<int, 3> fluid_mask_;
 
 }; // end SurrogateHeatDriver
 

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -2,6 +2,7 @@
 
 #include "enrico/error.h"
 #include "nek5000/core/nek_interface.h"
+#include "iapws/iapws.h"
 
 #include <gsl/gsl>
 
@@ -13,7 +14,7 @@
 namespace enrico {
 
 NekDriver::NekDriver(MPI_Comm comm, pugi::xml_node node)
-  : Driver(comm)
+  : HeatFluidsDriver(comm)
 {
   lelg_ = nek_get_lelg();
   lelt_ = nek_get_lelt();
@@ -35,54 +36,6 @@ NekDriver::NekDriver(MPI_Comm comm, pugi::xml_node node)
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
-
-// This version sets the local-to-global element ordering, as ensured by a Gatherv
-// operation. It is currently unused, as the coupling does not need to know the
-// local-global ordering. void NekDriver::init_mappings() {
-//   if(active()) {
-//
-//     // These arrays are only gathered on the root process
-//     if (comm_.rank == 0) {
-//       local_counts_.reserve(comm_.size);
-//       local_displs_.reserve(comm_.size);
-//       local_ordering_.reserve(nelgt_);
-//     }
-//
-//     // Every proc sets a mapping from its local to global element indices.
-//     // This mapping is in a Nek5000 common block, but we don't expose it to C++
-//     int local_to_global[nelt_];
-//     for (int i = 0; i < nelt_; ++i) {
-//       local_to_global[i] = nek_get_global_elem(i+1) - 1;
-//     }
-//
-//     // The root proc gets every proc's local element count.
-//     comm_.Gather(&nelt_, 1, MPI_INT, local_counts_.data(), 1, MPI_INT);
-//
-//     if (comm_.rank == 0) {
-//       // The root makes a list of data displacements for a Gatherv operation.
-//       // Each proc's data will be displaced by the number of local elements on
-//       // the previous proc.
-//       local_displs_.at(0) = 0;
-//       for (int i = 1; i < comm_.rank; ++i) {
-//         local_displs_.at(i) = local_displs_.at(i-1) + local_counts_.at(i-1);
-//       }
-//
-//       // The root the gets the local-to-global element mapping for all procs.
-//       // This can be used to reorder the data from a Gatherv operation.
-//       comm_.Gatherv(
-//           local_to_global, nelt_, MPI_INT,
-//           local_ordering_.data(), local_counts_.data(), local_displs_.data(), MPI_INT
-//       );
-//     }
-//     else {
-//       // Other procs send their local-to-global mapping to the root.
-//       comm_.Gatherv(
-//           local_to_global, nelt_, MPI_INT,
-//           nullptr, nullptr, nullptr, MPI_INT
-//       );
-//     }
-//   }
-// }
 
 void NekDriver::init_session_name()
 {
@@ -115,7 +68,7 @@ xt::xtensor<double, 1> NekDriver::temperature() const
   // Each Nek proc finds the temperatures of its local elements
   double local_elem_temperatures[nelt_];
   for (int i = 0; i < nelt_; ++i) {
-    local_elem_temperatures[i] = get_local_elem_temperature(i + 1);
+    local_elem_temperatures[i] = temperature(i + 1);
   }
 
   xt::xtensor<double, 1> global_elem_temperatures = xt::xtensor<double, 1>();
@@ -138,21 +91,71 @@ xt::xtensor<double, 1> NekDriver::temperature() const
   return global_elem_temperatures;
 }
 
+xt::xtensor<int, 1> NekDriver::fluid_mask() const
+{
+  int local_fluid_mask[nelt_];
+  for (int i = 0; i < nelt_; ++i) {
+    local_fluid_mask[i] = is_in_fluid(i);
+  }
+
+  auto global_fluid_mask = xt::xtensor<int, 1>();
+
+  if (comm_.rank == 0) {
+    global_fluid_mask.resize({gsl::narrow<std::size_t>(nelgt_)});
+  }
+
+  comm_.Gatherv(local_fluid_mask,
+                nelt_,
+                MPI_INT,
+                global_fluid_mask.data(),
+                local_counts_.data(),
+                local_displs_.data(),
+                MPI_INT);
+
+  return global_fluid_mask;
+};
+
+xt::xtensor<double, 1> NekDriver::density() const
+{
+  // TODO: Unitialized!
+  double local_densities[nelt_];
+
+  for (int i = 0; i < nelt_; ++i) {
+    if (is_in_fluid(i) == 1) {
+      auto vol = volume(i);
+      auto T = temperature(i);
+      // nu1 returns specific volume in [m^3/kg]
+      local_densities[i] = 1.0e-3 / iapws::nu1(pressure_, T);
+    }
+    else {
+      local_densities[i] = 0.0;
+    }
+  }
+
+  auto global_densities = xt::xtensor<double, 1>();
+
+  if (comm_.rank == 0) {
+    global_densities.resize({gsl::narrow<std::size_t>(nelgt_)});
+  }
+
+  comm_.Gatherv(local_densities,
+                nelt_,
+                MPI_DOUBLE,
+                global_densities.data(),
+                local_counts_.data(),
+                local_displs_.data(),
+                MPI_DOUBLE);
+
+  return global_densities;
+}
+
 void NekDriver::solve_step()
 {
   nek_reset_counters();
   C2F_nek_solve();
 }
 
-Position NekDriver::get_global_elem_centroid(int global_elem) const
-{
-  double x, y, z;
-  err_chk(nek_get_global_elem_centroid(global_elem, &x, &y, &z),
-          "Could not find centroid of global element " + std::to_string(global_elem));
-  return {x, y, z};
-}
-
-Position NekDriver::get_local_elem_centroid(int local_elem) const
+Position NekDriver::centroid(int local_elem) const
 {
   double x, y, z;
   err_chk(nek_get_local_elem_centroid(local_elem, &x, &y, &z),
@@ -160,7 +163,7 @@ Position NekDriver::get_local_elem_centroid(int local_elem) const
   return {x, y, z};
 }
 
-double NekDriver::get_local_elem_volume(int local_elem) const
+double NekDriver::volume(int local_elem) const
 {
   double volume;
   err_chk(nek_get_local_elem_volume(local_elem, &volume),
@@ -168,7 +171,7 @@ double NekDriver::get_local_elem_volume(int local_elem) const
   return volume;
 }
 
-double NekDriver::get_local_elem_temperature(int local_elem) const
+double NekDriver::temperature(int local_elem) const
 {
   double temperature;
   err_chk(nek_get_local_elem_temperature(local_elem, &temperature),
@@ -176,17 +179,7 @@ double NekDriver::get_local_elem_temperature(int local_elem) const
   return temperature;
 }
 
-bool NekDriver::global_elem_is_in_rank(int global_elem) const
-{
-  return (nek_global_elem_is_in_rank(global_elem, comm_.rank) == 1);
-}
-
-int NekDriver::global_elem_is_in_fluid(int global_elem) const
-{
-  return nek_global_elem_is_in_fluid(global_elem);
-}
-
-int NekDriver::local_elem_is_in_fluid(int local_elem) const
+int NekDriver::is_in_fluid(int local_elem) const
 {
   return nek_local_elem_is_in_fluid(local_elem);
 }

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -13,8 +13,8 @@
 
 namespace enrico {
 
-NekDriver::NekDriver(MPI_Comm comm, pugi::xml_node node)
-  : HeatFluidsDriver(comm)
+NekDriver::NekDriver(MPI_Comm comm, double pressure, pugi::xml_node node)
+  : HeatFluidsDriver(comm, pressure)
 {
   lelg_ = nek_get_lelg();
   lelt_ = nek_get_lelt();

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -18,7 +18,8 @@ OpenmcHeatDriver::OpenmcHeatDriver(MPI_Comm comm, pugi::xml_node node)
   // Initialize OpenMC and surrogate heat drivers
   openmc_driver_ = std::make_unique<OpenmcDriver>(comm);
   pugi::xml_node surr_node = node.child("heat_surrogate");
-  heat_driver_ = std::make_unique<SurrogateHeatDriver>(comm, surr_node);
+  double pressure = {node.child("pressure").text().as_double()};
+  heat_driver_ = std::make_unique<SurrogateHeatDriver>(comm, pressure, surr_node);
 
   // Create mappings for fuel pins and setup tallies for OpenMC
   init_mappings();

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -105,7 +105,7 @@ void OpenmcNekDriver::init_mappings()
     // Only the OpenMC procs get the global element centroids/fluid-identities
     if (openmc_driver_->active()) {
       elem_centroids_.resize(n_global_elem_);
-      elem_fluid_mask_.resize(n_global_elem_);
+      elem_fluid_mask_.resize({n_global_elem_});
     }
     // Step 1: Get global element centroids/fluid-identities on all OpenMC ranks
     // Each Nek proc finds the centroids/fluid-identities of its local elements

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -39,7 +39,7 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
 
   // Instantiate OpenMC and Nek drivers
   openmc_driver_ = std::make_unique<OpenmcDriver>(openmc_comm);
-  nek_driver_ = std::make_unique<NekDriver>(comm, nek_node);
+  nek_driver_ = std::make_unique<NekDriver>(comm, pressure_, nek_node);
 
   // Determine number of local/global elements for each rank
   n_local_elem_ = nek_driver_->active() ? nek_driver_->nelt_ : 0;

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -107,8 +107,8 @@ void OpenmcNekDriver::init_mappings()
     Position local_element_centroids[n_local_elem_];
     int local_element_is_in_fluid[n_local_elem_];
     for (int i = 0; i < n_local_elem_; ++i) {
-      local_element_centroids[i] = nek_driver_->get_local_elem_centroid(i + 1);
-      local_element_is_in_fluid[i] = nek_driver_->local_elem_is_in_fluid(i + 1);
+      local_element_centroids[i] = nek_driver_->centroid(i + 1);
+      local_element_is_in_fluid[i] = nek_driver_->is_in_fluid(i + 1);
     }
     // Gather all the local element centroids/fluid-identities on the Nek5000/OpenMC root
     nek_driver_->comm_.Gatherv(local_element_centroids,
@@ -253,7 +253,7 @@ void OpenmcNekDriver::init_volumes()
     // Every Nek proc gets its local element volumes (lev)
     double local_elem_volumes[n_local_elem_];
     for (int i = 0; i < n_local_elem_; ++i) {
-      local_elem_volumes[i] = nek_driver_->get_local_elem_volume(i + 1);
+      local_elem_volumes[i] = nek_driver_->volume(i + 1);
     }
     // Gather all the local element volumes on the Nek5000/OpenMC root
     nek_driver_->comm_.Gatherv(local_elem_volumes,

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -89,6 +89,7 @@ void SurrogateHeatDriver::generate_arrays()
   source_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
   temperature_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
   density_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
+  fluid_mask_ = xt::zeros<int>({n_pins_, n_axial_, n_rings()});
 }
 
 void SurrogateHeatDriver::solve_step()
@@ -135,6 +136,10 @@ double SurrogateHeatDriver::temperature(int pin, int axial, int ring) const
 
 xt::xtensor<double, 1> SurrogateHeatDriver::density() const {
   return xt::flatten(density_);
+}
+
+xt::xtensor<int, 1> SurrogateHeatDriver::fluid_mask() const {
+  return xt::flatten(fluid_mask_);
 }
 
 void SurrogateHeatDriver::write_step(int timestep, int iteration)

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -12,7 +12,7 @@
 namespace enrico {
 
 SurrogateHeatDriver::SurrogateHeatDriver(MPI_Comm comm, pugi::xml_node node)
-  : Driver(comm)
+  : HeatFluidsDriver(comm)
 {
   // Determine heat transfer solver parameters
   clad_inner_radius_ = node.child("clad_inner_radius").text().as_double();
@@ -88,6 +88,7 @@ void SurrogateHeatDriver::generate_arrays()
   // Create empty arrays for source term and temperature
   source_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
   temperature_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
+  density_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
 }
 
 void SurrogateHeatDriver::solve_step()
@@ -130,6 +131,10 @@ xt::xtensor<double, 1> SurrogateHeatDriver::temperature() const
 double SurrogateHeatDriver::temperature(int pin, int axial, int ring) const
 {
   return temperature_(pin, axial, ring);
+}
+
+xt::xtensor<double, 1> SurrogateHeatDriver::density() const {
+  return xt::flatten(density_);
 }
 
 void SurrogateHeatDriver::write_step(int timestep, int iteration)

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -11,8 +11,8 @@
 
 namespace enrico {
 
-SurrogateHeatDriver::SurrogateHeatDriver(MPI_Comm comm, pugi::xml_node node)
-  : HeatFluidsDriver(comm)
+SurrogateHeatDriver::SurrogateHeatDriver(MPI_Comm comm, double pressure, pugi::xml_node node)
+  : HeatFluidsDriver(comm, pressure)
 {
   // Determine heat transfer solver parameters
   clad_inner_radius_ = node.child("clad_inner_radius").text().as_double();

--- a/tests/singlerod/short/test_nek5000.cpp
+++ b/tests/singlerod/short/test_nek5000.cpp
@@ -15,7 +15,10 @@ int main(int argc, char *argv[]) {
   auto root = doc.document_element();
 
   {
-    enrico::NekDriver test_driver(MPI_COMM_WORLD, root.child("nek5000"));
+    enrico::NekDriver test_driver(
+        MPI_COMM_WORLD,
+        root.child("pressure").text().as_double(),
+        root.child("nek5000"));
     test_driver.init_step();
     test_driver.solve_step();
     test_driver.finalize_step();


### PR DESCRIPTION
This introduces a `HeatFluidsDriver` base class from which `NekDriver` and `SurrogateHeatDriver` are derived.  

`HeatFluidsDriver` declares:
  * `pressure_`:  The system pressure.  Must be passed to the constructor.  
  * `density()`:  Returns a flattened xtensor of densities for each region.  The semantics of a "region" are left up to the derived class
  * `fluid_mask()`:  Returns a flattened xtensor of integers.  For each region, states whether that region is in fluid.  

These classes were also changed:  
* `NekDriver`:  
  * From `density()`, the fluid elements have meaningful densities and the solid elements have zero density.  Any coupled driver that uses the densities should also use `fluid_mask()` to filter the meaningful data.  
* `OpenmcNekDriver`:
  * When instantiating the `NekDriver`, the system pressure from `enrico.xml` is passed to the `NekDriver` constructor.  
  * Has a new data member, `elem_densities_` that is updated from `NekDriver::density()`
  * Has a new data member `elem_fluid_mask_` that is instantiated from `NekDriver::fluid_mask()`
  * Has a new data member `cell_fluid_mask_` that is instantiated in `init_cell_mask()`.  
  * Has a new member function `update_cell_density()` that updates fluid densities based on `elem_densities_` and `cell_fluid_mask_`.   
* `SurrogateHeatDriver`:  
  * `pressure_` is not used but must still be passed to the constructor
  * `fluid_mask` is all zeros.  

TODO:
- [ ] Sanity check for simulation output

Fixes #14 