### PR TITLE
Use assertions from GSL in SMRT files

### DIFF
--- a/include/smrt/Assembly_Model.h
+++ b/include/smrt/Assembly_Model.h
@@ -3,10 +3,15 @@
 
 #include <vector>
 
+// Trilinos includes
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_RCP.hpp"
 
+// SCALE includes
 #include "Nemesis/harness/DBC.hh"
+
+// vendored includes
+#include <gsl/gsl>
 
 namespace enrico {
 
@@ -48,21 +53,21 @@ public:
   // Set fuel pin radius
   void set_fuel_radius(double fr)
   {
-    Require(fr > 0);
+    Expects(fr > 0);
     d_fuel_radius = fr;
   }
 
   // Set clad outer radius
   void set_clad_radius(double cr)
   {
-    Require(cr > 0);
+    Expects(cr > 0);
     d_clad_radius = cr;
   }
 
   // Set guide tube outer radius
   void set_guide_radius(double gr)
   {
-    Require(gr > 0);
+    Expects(gr > 0);
     d_guide_radius = gr;
   }
 
@@ -79,24 +84,24 @@ public:
   // Convert (i,j) to cardinal pin index
   int pin_id(int i, int j) const
   {
-    Require(i < d_Nx);
-    Require(j < d_Ny);
+    Expects(i < d_Nx);
+    Expects(j < d_Ny);
     return i + d_Nx * j;
   }
 
   // Convert (i,j,k) to cardinal index
   int index(int i, int j, int k) const
   {
-    Require(i < d_Nx);
-    Require(j < d_Ny);
+    Expects(i < d_Nx);
+    Expects(j < d_Ny);
     return pin_id(i, j) + num_pins() * k;
   }
 
   // Type of pin at (i,j) location
   PIN_TYPE pin_type(int i, int j) const
   {
-    Require(i < d_Nx);
-    Require(j < d_Ny);
+    Expects(i < d_Nx);
+    Expects(j < d_Ny);
     return d_pin_map[pin_id(i, j)];
   }
 

--- a/include/smrt/Multi_Pin_Subchannel.h
+++ b/include/smrt/Multi_Pin_Subchannel.h
@@ -8,6 +8,9 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_RCP.hpp"
 
+// vendored includes
+#include <gsl/gsl>
+
 // enrico includes
 #include "Assembly_Model.h"
 #include "Single_Pin_Subchannel.h"
@@ -60,8 +63,8 @@ public:
 private:
   int channel_index(int ix, int iy) const
   {
-    Require(ix < d_Nx);
-    Require(iy < d_Ny);
+    Expects(ix < d_Nx);
+    Expects(iy < d_Ny);
     return ix + d_Nx * iy;
   }
 };

--- a/include/smrt/Single_Pin_Conduction.h
+++ b/include/smrt/Single_Pin_Conduction.h
@@ -3,13 +3,18 @@
 
 #include <vector>
 
+// Trilinos includes
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_SerialDenseSolver.hpp"
 #include "Teuchos_SerialDenseVector.hpp"
 
+// SCALE includes
 #include "Nemesis/harness/DBC.hh"
+
+// vendored includes
+#include <gsl/gsl>
 
 namespace enrico {
 
@@ -56,16 +61,16 @@ public:
   // Set fuel radius (cm)
   void set_fuel_radius(double r)
   {
-    Require(r > 0.0);
-    Require(r < 2.0);
+    Expects(r > 0.0);
+    Expects(r < 2.0);
     d_fuel_radius = r;
   }
 
   // Set clad radius (cm)
   void set_clad_radius(double r)
   {
-    Require(r > 0.0);
-    Require(r < 2.0);
+    Expects(r > 0.0);
+    Expects(r < 2.0);
     d_clad_radius = r;
   }
 

--- a/include/smrt/Single_Pin_Subchannel.h
+++ b/include/smrt/Single_Pin_Subchannel.h
@@ -10,6 +10,9 @@
 // SCALE includes
 #include "Nemesis/harness/DBC.hh"
 
+// vendored includes
+#include <gsl/gsl>
+
 namespace enrico {
 
 //===========================================================================//
@@ -60,31 +63,31 @@ public:
   void set_channel_area(double area)
   {
     // Channel area internally is needed in m^2
-    Require(area > 0.0);
+    Expects(area > 0.0);
     d_area = 1e-4 * area;
   }
 
   // Set mass flow rate (kg/s)
   void set_mass_flow_rate(double mdot)
   {
-    Require(mdot > 0.0);
-    Require(mdot < 2.0);
+    Expects(mdot > 0.0);
+    Expects(mdot < 2.0);
     d_mdot = mdot;
   }
 
   // Set inlet temperature (K)
   void set_inlet_temperature(double T)
   {
-    Require(T > 0);
-    Require(T < 1000);
+    Expects(T > 0);
+    Expects(T < 1000);
     d_T_inlet = T;
   }
 
   // Set exit pressure (Pa)
   void set_exit_pressure(double p)
   {
-    Require(p > 0);
-    Require(p < 2.2e7);
+    Expects(p > 0);
+    Expects(p < 2.2e7);
     d_p_exit = p;
   }
 

--- a/include/smrt/Two_Group_Diffusion.h
+++ b/include/smrt/Two_Group_Diffusion.h
@@ -18,6 +18,9 @@
 #include "Nemesis/comm/global.hh"
 #include "Nemesis/harness/DBC.hh"
 
+// vendored includes
+#include <gsl/gsl>
+
 // enrico includes
 #include "Assembly_Model.h"
 #include "Neutronics_Solver.h"
@@ -96,15 +99,15 @@ public:
 private:
   int cellid(int ix, int iy, int iz)
   {
-    Require(ix >= 0);
-    Require(ix < d_Nx);
-    Require(iy >= 0);
-    Require(iy < d_Ny);
-    Require(iz >= 0);
-    Require(iz < d_Nz);
+    Expects(ix >= 0);
+    Expects(ix < d_Nx);
+    Expects(iy >= 0);
+    Expects(iy < d_Ny);
+    Expects(iz >= 0);
+    Expects(iz < d_Nz);
     int cell = ix + d_Nx * (iy + d_Ny * iz);
-    Ensure(cell >= 0);
-    Ensure(cell < d_num_cells);
+    Ensures(cell >= 0);
+    Ensures(cell < d_num_cells);
     return cell;
   }
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -1,5 +1,7 @@
 #include "enrico/coupled_driver.h"
+
 #include "enrico/driver.h"
+
 #include "xtensor/xnorm.hpp"
 #include <gsl/gsl>
 

--- a/src/smrt/Assembly_Model.cpp
+++ b/src/smrt/Assembly_Model.cpp
@@ -1,6 +1,10 @@
 #include "smrt/Assembly_Model.h"
 
+// SCALE includes
 #include "Nemesis/utils/Constants.hh"
+
+// vendored includes
+#include <gsl/gsl>
 
 namespace enrico {
 //---------------------------------------------------------------------------//
@@ -17,7 +21,7 @@ Assembly_Model::Assembly_Model(const std::vector<PIN_TYPE>& pin_map,
 {
   d_Nx = d_x_edges.size() - 1;
   d_Ny = d_y_edges.size() - 1;
-  Require(d_pin_map.size() == d_Nx * d_Ny);
+  Expects(d_pin_map.size() == d_Nx * d_Ny);
 }
 
 //---------------------------------------------------------------------------//
@@ -72,8 +76,8 @@ Assembly_Model::Assembly_Model(Teuchos::RCP<Teuchos::ParameterList> params)
 //---------------------------------------------------------------------------//
 double Assembly_Model::flow_area(int i, int j) const
 {
-  Require(i < d_Nx);
-  Require(j < d_Ny);
+  Expects(i < d_Nx);
+  Expects(j < d_Ny);
 
   double dx = d_x_edges[i + 1] - d_x_edges[i];
   double dy = d_y_edges[j + 1] - d_y_edges[j];
@@ -84,10 +88,10 @@ double Assembly_Model::flow_area(int i, int j) const
     r = d_clad_radius;
   else if (type == GUIDE)
     r = d_guide_radius;
-  Check(r > 0.0);
+  Expects(r > 0.0);
 
   double area = dx * dy - nemesis::constants::pi * r * r;
-  Ensure(area > 0);
+  Ensures(area > 0);
   return area;
 }
 

--- a/src/smrt/Assembly_Model.cpp
+++ b/src/smrt/Assembly_Model.cpp
@@ -32,10 +32,10 @@ Assembly_Model::Assembly_Model(Teuchos::RCP<Teuchos::ParameterList> params)
   using Array_Dbl = Teuchos::Array<double>;
   using Array_Str = Teuchos::Array<std::string>;
 
-  Validate(params->isType<Array_Dbl>("x_edges"), "Must specify 'x_edges'.");
-  Validate(params->isType<Array_Dbl>("y_edges"), "Must specify 'y_edges'.");
-  Validate(params->isType<Array_Dbl>("z_edges"), "Must specify 'z_edges'.");
-  Validate(params->isType<Array_Str>("pin_map"), "Must specify 'pin_map'.");
+  Expects(params->isType<Array_Dbl>("x_edges"));
+  Expects(params->isType<Array_Dbl>("y_edges"));
+  Expects(params->isType<Array_Dbl>("z_edges"));
+  Expects(params->isType<Array_Str>("pin_map"));
 
   // Get x/y/z edges
   auto x = params->get<Array_Dbl>("x_edges");
@@ -49,16 +49,11 @@ Assembly_Model::Assembly_Model(Teuchos::RCP<Teuchos::ParameterList> params)
 
   // Translate pin map strings to enums
   auto pins = params->get<Array_Str>("pin_map");
-  Validate(pins.size() == d_Nx * d_Ny,
-           "Expected pin map to be size " << d_Nx * d_Ny << " but actual size is "
-                                          << pins.size());
+  Expects(pins.size() == d_Nx * d_Ny);
   d_pin_map.resize(d_Nx * d_Ny);
   for (int pin = 0; pin < d_Nx * d_Ny; ++pin) {
     auto val = pins[pin];
-    Validate(val == "Fuel" || val == "Guide",
-             "Pin map entries must be 'Fuel' or 'Guide', "
-             " entry "
-               << pin << " is " << val);
+    Expects(val == "Fuel" || val == "Guide");
     if (val == "Fuel")
       d_pin_map[pin] = FUEL;
     else

--- a/src/smrt/Multi_Pin_Conduction.cpp
+++ b/src/smrt/Multi_Pin_Conduction.cpp
@@ -2,6 +2,8 @@
 
 #include "Nemesis/harness/Soft_Equivalence.hh"
 
+#include <gsl/gsl>
+
 namespace enrico {
 //---------------------------------------------------------------------------//
 // Constructor
@@ -11,7 +13,7 @@ Multi_Pin_Conduction::Multi_Pin_Conduction(SP_Assembly assembly,
                                            const std::vector<double>& dz)
   : d_assembly(assembly)
 {
-  Require(d_assembly);
+  Expects(d_assembly);
 
   d_Nz = dz.size();
 
@@ -21,7 +23,7 @@ Multi_Pin_Conduction::Multi_Pin_Conduction(SP_Assembly assembly,
   d_pin_conduction->set_clad_radius(d_assembly->clad_radius());
 
   double height = std::accumulate(dz.begin(), dz.end(), 0.0);
-  Check(nemesis::soft_equiv(height, d_assembly->height()));
+  Expects(nemesis::soft_equiv(height, d_assembly->height()));
 }
 
 //---------------------------------------------------------------------------//
@@ -35,9 +37,9 @@ void Multi_Pin_Conduction::solve(const std::vector<double>& power,
   int Ny = d_assembly->num_pins_y();
   int N = Nx * Ny * d_Nz;
 
-  Require(power.size() == N);
-  Require(channel_temp.size() == N);
-  Require(fuel_temp.size() == N);
+  Expects(power.size() == N);
+  Expects(channel_temp.size() == N);
+  Expects(fuel_temp.size() == N);
 
   // Storage for single pin values
   std::vector<double> pin_power(d_Nz);
@@ -59,7 +61,7 @@ void Multi_Pin_Conduction::solve(const std::vector<double>& power,
         d_pin_conduction->solve(pin_power, pin_channel_temp, pin_fuel_temp);
       } else {
         for (int iz = 0; iz < d_Nz; ++iz)
-          Check(pin_power[iz] == 0);
+          Expects(pin_power[iz] == 0);
 
         // "Fuel" temp is same as channel temp in guide tubes
         std::copy(

--- a/src/smrt/Multi_Pin_Conduction.cpp
+++ b/src/smrt/Multi_Pin_Conduction.cpp
@@ -13,7 +13,7 @@ Multi_Pin_Conduction::Multi_Pin_Conduction(SP_Assembly assembly,
                                            const std::vector<double>& dz)
   : d_assembly(assembly)
 {
-  Expects(d_assembly);
+  Expects(d_assembly != nullptr);
 
   d_Nz = dz.size();
 

--- a/src/smrt/Multi_Pin_Subchannel.cpp
+++ b/src/smrt/Multi_Pin_Subchannel.cpp
@@ -3,6 +3,7 @@
 #include "smrt/Multi_Pin_Subchannel.h"
 
 #include "Nemesis/harness/Soft_Equivalence.hh"
+#include <gsl/gsl>
 
 namespace enrico {
 //---------------------------------------------------------------------------//
@@ -13,10 +14,10 @@ Multi_Pin_Subchannel::Multi_Pin_Subchannel(SP_Assembly assembly,
                                            const std::vector<double>& dz)
   : d_assembly(assembly)
 {
-  Require(d_assembly);
+  Expects(d_assembly);
 
   double height = std::accumulate(dz.begin(), dz.end(), 0.0);
-  Check(nemesis::soft_equiv(height, d_assembly->height()));
+  Expects(nemesis::soft_equiv(height, d_assembly->height()));
 
   double mdot_per_area = parameters->get("mass_flow_rate", 0.4);
 
@@ -64,16 +65,16 @@ void Multi_Pin_Subchannel::solve(const std::vector<double>& pin_powers,
 {
   int pins_x = d_assembly->num_pins_x();
   int pins_y = d_assembly->num_pins_y();
-  Require(pin_powers.size() == pins_x * pins_y * d_Nz);
-  Require(pin_temps.size() == pins_x * pins_y * d_Nz);
-  Require(pin_densities.size() == pins_x * pins_y * d_Nz);
+  Expects(pin_powers.size() == pins_x * pins_y * d_Nz);
+  Expects(pin_temps.size() == pins_x * pins_y * d_Nz);
+  Expects(pin_densities.size() == pins_x * pins_y * d_Nz);
 
   // Convenience function to compute pin index
   auto pin_index = [pins_x, pins_y](int ix, int iy, int iz) {
-    Check(ix >= 0);
-    Check(iy >= 0);
-    Check(ix < pins_x);
-    Check(iy < pins_y);
+    Expects(ix >= 0);
+    Expects(iy >= 0);
+    Expects(ix < pins_x);
+    Expects(iy < pins_y);
     return ix + pins_x * (iy + pins_y * iz);
   };
 

--- a/src/smrt/Multi_Pin_Subchannel.cpp
+++ b/src/smrt/Multi_Pin_Subchannel.cpp
@@ -14,7 +14,7 @@ Multi_Pin_Subchannel::Multi_Pin_Subchannel(SP_Assembly assembly,
                                            const std::vector<double>& dz)
   : d_assembly(assembly)
 {
-  Expects(d_assembly);
+  Expects(d_assembly != nullptr);
 
   double height = std::accumulate(dz.begin(), dz.end(), 0.0);
   Expects(nemesis::soft_equiv(height, d_assembly->height()));

--- a/src/smrt/Multiphysics_Driver.cpp
+++ b/src/smrt/Multiphysics_Driver.cpp
@@ -10,11 +10,16 @@
 
 #include "smrt/Multiphysics_Driver.h"
 
+// SCALE includes
 #include "Nemesis/comm/Logger.hh"
-#include "Nemesis/harness/Soft_Equivalence.hh"
-
 #include "Nemesis/comm/global.hh"
+#include "Nemesis/harness/Soft_Equivalence.hh"
 #include "Omnibus/config.h"
+
+// vendored includes
+#include <gsl/gsl>
+
+// enrico includes
 #include "smrt/Two_Group_Diffusion.h"
 #ifdef USE_SHIFT
 #include "smrt/shift_driver.h"
@@ -31,11 +36,7 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
 {
   Expects(assembly);
 
-  Validate(nemesis::soft_equiv(z_edges.back(), d_assembly->height()),
-           "End of axial edges " << z_edges.back()
-                                 << " does not match "
-                                    " assembly height "
-                                 << d_assembly->height());
+  Expects(nemesis::soft_equiv(z_edges.back(), d_assembly->height()));
 
   Vec_Dbl dz(z_edges.size() - 1);
   for (int edge = 0; edge < dz.size(); ++edge)
@@ -74,15 +75,13 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
     d_neutronics = std::make_shared<Two_Group_Diffusion>(assembly, neutronics_params, dz);
   } else {
 #ifdef USE_SHIFT
-    Validate(neutronics_params->isType<std::string>("shift_input"),
-             "Neutronics type set to 'shift', "
-             "but no 'shift_input' specified.");
+    // Neutronics type set to 'shift', but no 'shift_input' specified
+    Expects(neutronics_params->isType<std::string>("shift_input"));
     auto shift_input = neutronics_params->get<std::string>("shift_input");
     d_neutronics = std::make_shared<ShiftDriver>(assembly, shift_input, z_edges);
 #else
-    Validate(false,
-             "Neutronics type set to 'shift', but Shift is not "
-             "enabled in this build.");
+    // Neutronics type set to 'shift', but Shift is not enabled in this build.
+    Expects(false);
 #endif
   }
 }

--- a/src/smrt/Multiphysics_Driver.cpp
+++ b/src/smrt/Multiphysics_Driver.cpp
@@ -34,7 +34,7 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
                                          const Vec_Dbl& z_edges)
   : d_assembly(assembly)
 {
-  Expects(assembly);
+  Expects(assembly != nullptr);
 
   Expects(nemesis::soft_equiv(z_edges.back(), d_assembly->height()));
 

--- a/src/smrt/Multiphysics_Driver.cpp
+++ b/src/smrt/Multiphysics_Driver.cpp
@@ -29,7 +29,7 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
                                          const Vec_Dbl& z_edges)
   : d_assembly(assembly)
 {
-  Require(assembly);
+  Expects(assembly);
 
   Validate(nemesis::soft_equiv(z_edges.back(), d_assembly->height()),
            "End of axial edges " << z_edges.back()

--- a/src/smrt/Single_Pin_Conduction.cpp
+++ b/src/smrt/Single_Pin_Conduction.cpp
@@ -31,11 +31,11 @@ void Single_Pin_Conduction::solve(const std::vector<double>& power,
                                   const std::vector<double>& channel_temp,
                                   std::vector<double>& fuel_temp)
 {
-  Require(power.size() == d_delta_z.size());
-  Require(channel_temp.size() == d_delta_z.size());
-  Require(fuel_temp.size() == d_delta_z.size());
-  Require(d_fuel_radius > 0.0);
-  Require(d_clad_radius > d_fuel_radius);
+  Expects(power.size() == d_delta_z.size());
+  Expects(channel_temp.size() == d_delta_z.size());
+  Expects(fuel_temp.size() == d_delta_z.size());
+  Expects(d_fuel_radius > 0.0);
+  Expects(d_clad_radius > d_fuel_radius);
 
   using nemesis::constants::pi;
 
@@ -45,7 +45,7 @@ void Single_Pin_Conduction::solve(const std::vector<double>& power,
   int num_rings_fuel = std::ceil(d_fuel_radius / d_delta_r_fuel);
   int num_rings_clad = std::ceil((d_clad_radius - d_fuel_radius) / d_delta_r_clad);
   int num_rings = num_rings_fuel + num_rings_clad;
-  Check(num_rings > 2);
+  Expects(num_rings > 2);
 
   // Compute delta r in fuel and clad
   std::vector<double> radius(num_rings + 1);
@@ -56,7 +56,7 @@ void Single_Pin_Conduction::solve(const std::vector<double>& power,
   dr = (d_clad_radius - d_fuel_radius) / static_cast<double>(num_rings_clad);
   for (int r = num_rings_fuel; r < num_rings; ++r)
     radius[r + 1] = radius[r] + dr;
-  Check(nemesis::soft_equiv(radius[num_rings], d_clad_radius));
+  Expects(nemesis::soft_equiv(radius[num_rings], d_clad_radius));
 
   // Assign thermal conductivity in fuel and clad
   std::vector<double> k(num_rings);
@@ -70,10 +70,10 @@ void Single_Pin_Conduction::solve(const std::vector<double>& power,
   }
   // Check areas
   double fuel_area = std::accumulate(area.begin(), area.begin() + num_rings_fuel, 0.0);
-  Check(nemesis::soft_equiv(fuel_area, pi * d_fuel_radius * d_fuel_radius));
+  Expects(nemesis::soft_equiv(fuel_area, pi * d_fuel_radius * d_fuel_radius));
 
   double total_area = std::accumulate(area.begin(), area.end(), 0.0);
-  Check(nemesis::soft_equiv(total_area, pi * d_clad_radius * d_clad_radius));
+  Expects(nemesis::soft_equiv(total_area, pi * d_clad_radius * d_clad_radius));
 
   auto rcp_matrix = Teuchos::rcp(new Matrix(num_rings, num_rings));
   auto rcp_rhs = Teuchos::rcp(new Vector(num_rings));
@@ -124,7 +124,7 @@ void Single_Pin_Conduction::solve(const std::vector<double>& power,
     solver.equilibrateRHS();
     int err = solver.solve();
     solver.unequilibrateLHS();
-    Check(err == 0);
+    Expects(err == 0);
 
     // Compute average fuel temperature for this level
     double ft = 0.0;

--- a/src/smrt/Single_Pin_Subchannel.cpp
+++ b/src/smrt/Single_Pin_Subchannel.cpp
@@ -4,7 +4,11 @@
 #include "smrt/Single_Pin_Subchannel.h"
 #include "smrt/Water_Properties.h"
 
+// SCALE includes
 #include "Nemesis/utils/String_Functions.hh"
+
+// vendored includes
+#include <gsl/gsl>
 
 namespace enrico {
 //---------------------------------------------------------------------------//
@@ -25,14 +29,16 @@ Single_Pin_Subchannel::Single_Pin_Subchannel(RCP_PL& parameters,
     val *= 1e-2;
 
   auto verb = nemesis::lower(parameters->get("verbosity", std::string("none")));
-  if (verb == "none")
+  if (verb == "none") {
     d_verbosity = NONE;
-  else if (verb == "low")
+  } else if (verb == "low") {
     d_verbosity = LOW;
-  else if (verb == "high")
+  } else if (verb == "high") {
     d_verbosity = HIGH;
-  else
-    Validate(false, "Unrecognized verbosity.");
+  } else {
+    // Unrecognized verbosity.
+    Expects(false);
+  }
 }
 
 //---------------------------------------------------------------------------//

--- a/src/smrt/Single_Pin_Subchannel.cpp
+++ b/src/smrt/Single_Pin_Subchannel.cpp
@@ -46,11 +46,11 @@ void Single_Pin_Subchannel::solve(const std::vector<double>& power,
                                   std::vector<double>& temperature,
                                   std::vector<double>& density)
 {
-  Require(power.size() == d_delta_z.size());
-  Require(temperature.size() == d_delta_z.size());
-  Require(density.size() == d_delta_z.size());
-  Require(d_T_inlet > 0.0);
-  Require(d_p_exit > 0.0);
+  Expects(power.size() == d_delta_z.size());
+  Expects(temperature.size() == d_delta_z.size());
+  Expects(density.size() == d_delta_z.size());
+  Expects(d_T_inlet > 0.0);
+  Expects(d_p_exit > 0.0);
 
   int num_regions = d_delta_z.size();
 

--- a/src/smrt/Two_Group_Cross_Sections.cpp
+++ b/src/smrt/Two_Group_Cross_Sections.cpp
@@ -10,10 +10,10 @@ auto Two_Group_Cross_Sections::get_data(Assembly_Model::PIN_TYPE type,
                                         double T,
                                         double rho) -> XS_Data
 {
-  Require(T > 273);
-  Require(T < 3000);
-  Require(rho > 0);
-  Require(rho < 1);
+  Expects(T > 273);
+  Expects(T < 3000);
+  Expects(rho > 0);
+  Expects(rho < 1);
 
   constexpr double T_base = 1000;   // degrees K
   constexpr double rho_base = 0.75; // g/cc

--- a/src/smrt/Two_Group_Diffusion.cpp
+++ b/src/smrt/Two_Group_Diffusion.cpp
@@ -133,9 +133,9 @@ void Two_Group_Diffusion::solve(const Vec_Dbl& temperatures,
                                 const Vec_Dbl& densities,
                                 Vec_Dbl& powers)
 {
-  Require(temperatures.size() == d_num_cells);
-  Require(densities.size() == d_num_cells);
-  Require(powers.size() == d_num_cells);
+  Expects(temperatures.size() == d_num_cells);
+  Expects(densities.size() == d_num_cells);
+  Expects(powers.size() == d_num_cells);
 
   // Compute cross section data at given conditions
   std::vector<XS_Data> xs_data(d_num_cells);
@@ -197,7 +197,7 @@ void Two_Group_Diffusion::solve(const Vec_Dbl& temperatures,
     std::fill(fission.begin(), fission.end(), 1.0);
     fisn_nrm = std::sqrt(static_cast<double>(d_num_cells));
   }
-  Check(fisn_nrm > 0.0);
+  Expects(fisn_nrm > 0.0);
   scale_vec(fission, 1.0 / fisn_nrm);
 
   // Start solve
@@ -233,13 +233,13 @@ void Two_Group_Diffusion::solve(const Vec_Dbl& temperatures,
       fission_diff[cell] = fission[cell] - keff * b_fast_data[cell];
     }
     fisn_nrm = vec_norm(fission);
-    Check(fisn_nrm > 0.0);
+    Expects(fisn_nrm > 0.0);
     rel_err = vec_norm(fission_diff) / fisn_nrm;
 
     // Compute new keff
     keff *= (fisn_nrm / old_fisn_nrm);
-    Check(keff > 0.0);
-    Check(keff < 2.0);
+    Expects(keff > 0.0);
+    Expects(keff < 2.0);
 
     // Check for convergence
     if (rel_err < d_tol) {
@@ -275,7 +275,7 @@ void Two_Group_Diffusion::solve(const Vec_Dbl& temperatures,
 //---------------------------------------------------------------------------//
 void Two_Group_Diffusion::build_matrices(const std::vector<XS_Data>& xs_data)
 {
-  Require(xs_data.size() == d_num_cells);
+  Expects(xs_data.size() == d_num_cells);
 
   // Build matrices
   Vec_Int row_inds;

--- a/src/smrt/Two_Group_Diffusion.cpp
+++ b/src/smrt/Two_Group_Diffusion.cpp
@@ -10,6 +10,9 @@
 #include "BelosSolverFactory.hpp"
 #include "BelosTpetraAdapter.hpp"
 
+// vendored includes
+#include <gsl/gsl>
+
 namespace enrico {
 //---------------------------------------------------------------------------//
 // Constructor
@@ -45,15 +48,9 @@ Two_Group_Diffusion::Two_Group_Diffusion(SP_Assembly assembly,
   using Array_Str = Teuchos::Array<std::string>;
   if (params->isType<Array_Str>("boundary")) {
     auto bc_str = params->get<Array_Str>("boundary");
-    Validate(bc_str.size() == 6,
-             "Entry 'boundary' must have 6 values, "
-             "but only has "
-               << bc_str.size());
+    Expects(bc_str.size() == 6);
     for (int bdry = 0; bdry < 6; ++bdry) {
-      Validate(bc_str[bdry] == "vacuum" || bc_str[bdry] == "reflect",
-               "Values in 'boundary' must be 'vacuum' or 'reflect', "
-               " entry "
-                 << bdry << " is " << bc_str[bdry]);
+      Expects(bc_str[bdry] == "vacuum" || bc_str[bdry] == "reflect");
       if (bc_str[bdry] == "reflect")
         d_bcs[bdry] = REFLECT;
       else

--- a/src/smrt/Water_Properties.cpp
+++ b/src/smrt/Water_Properties.cpp
@@ -1,8 +1,11 @@
-#include <cmath>
-
 #include "smrt/Water_Properties.h"
 
+// SCALE includes
 #include "Nemesis/harness/DBC.hh"
+
+#include <gsl/gsl>
+
+#include <cmath>
 
 namespace enrico {
 
@@ -55,10 +58,10 @@ double Water_Properties::Density(double h, double p)
   p *= PA_TO_PSI;
   h *= JG_TO_BTULBM;
 
-  Check(p > 0.01);
-  Check(p < PCRIT);
-  Check(h > 0.0);
-  Check(h < HCRIT);
+  Expects(p > 0.01);
+  Expects(p < PCRIT);
+  Expects(h > 0.0);
+  Expects(h < HCRIT);
 
   double nu = 0.0;
   if (h < 250.0) {
@@ -115,10 +118,10 @@ double Water_Properties::Temperature(double h, double p)
   h = h * JG_TO_BTULBM;
 
   // Sanity check on inputs
-  Check(p > 0.01);
-  Check(p < PCRIT);
-  Check(h > 0.0);
-  Check(h < HCRIT);
+  Expects(p > 0.01);
+  Expects(p < PCRIT);
+  Expects(h > 0.0);
+  Expects(h < HCRIT);
 
   // Evaluate based on formula
   double T = 0.0;
@@ -157,7 +160,7 @@ double Water_Properties::Enthalpy(double T, double p)
 
   double fa = Temperature(a, p) - T;
   double fb = Temperature(b, p) - T;
-  Check(fa * fb < 0.0);
+  Expects(fa * fb < 0.0);
 
   double h;
 

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -51,9 +51,9 @@ ShiftDriver::ShiftDriver(SP_Assembly_Model assembly,
 
   // Store geometry
   auto problem_geom = problem->geometry();
-  Expects(problem_geom);
+  Expects(problem_geom != nullptr);
   d_geometry = std::dynamic_pointer_cast<Geometry>(problem_geom);
-  Expects(d_geometry);
+  Expects(d_geometry != nullptr);
 
   // Create or validate power tally
   add_power_tally(plist, z_edges);
@@ -171,7 +171,7 @@ void ShiftDriver::set_centroids_and_volumes(
 //---------------------------------------------------------------------------//
 void ShiftDriver::add_power_tally(RCP_PL& pl, const std::vector<double>& z_edges)
 {
-  Expects(d_assembly);
+  Expects(d_assembly != nullptr);
   auto tally_pl = Teuchos::sublist(pl, "TALLY");
   auto cell_pl = Teuchos::sublist(tally_pl, "CELL");
 

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -25,8 +25,8 @@ namespace enrico {
 // Constructor
 //---------------------------------------------------------------------------//
 ShiftDriver::ShiftDriver(SP_Assembly_Model assembly,
-                           std::string shift_input,
-                           const std::vector<double>& z_edges)
+                         std::string shift_input,
+                         const std::vector<double>& z_edges)
   : d_assembly(assembly)
   , d_power_tally_name("power")
 {
@@ -51,9 +51,9 @@ ShiftDriver::ShiftDriver(SP_Assembly_Model assembly,
 
   // Store geometry
   auto problem_geom = problem->geometry();
-  Check(problem_geom);
+  Expects(problem_geom);
   d_geometry = std::dynamic_pointer_cast<Geometry>(problem_geom);
-  Check(d_geometry);
+  Expects(d_geometry);
 
   // Create or validate power tally
   add_power_tally(plist, z_edges);
@@ -63,10 +63,10 @@ ShiftDriver::ShiftDriver(SP_Assembly_Model assembly,
 // Solve
 //---------------------------------------------------------------------------//
 void ShiftDriver::solve(const std::vector<double>& th_temperature,
-                         const std::vector<double>& coolant_density,
-                         std::vector<double>& power)
+                        const std::vector<double>& coolant_density,
+                        std::vector<double>& power)
 {
-  Require(th_temperature.size() == d_matids.size());
+  Expects(th_temperature.size() == d_matids.size());
   auto& comps = d_driver->compositions();
 
   // Average T/H mesh temperatures onto Shift materials
@@ -98,18 +98,18 @@ void ShiftDriver::solve(const std::vector<double>& th_temperature,
       // divide by volume to get volumetric power
       const auto& result = tally->result();
       auto mean = result.mean(0);
-      Check(result.num_multipliers() == 1);
+      Expects(result.num_multipliers() == 1);
 
       // Compute global sum for normalization
       double total_power = std::accumulate(mean.begin(), mean.end(), 0.0);
 
       for (int cellid = 0; cellid < mean.size(); ++cellid) {
-        Check(cellid < d_power_map.size());
+        Expects(cellid < d_power_map.size());
         const auto& elem_list = d_power_map[cellid];
         double tally_volume = d_geometry->cell_volume(cellid);
 
         for (const auto& elem : elem_list) {
-          Check(elem < power.size());
+          Expects(elem < power.size());
           power[elem] = mean[cellid] / tally_volume / total_power;
         }
       }
@@ -171,7 +171,7 @@ void ShiftDriver::set_centroids_and_volumes(
 //---------------------------------------------------------------------------//
 void ShiftDriver::add_power_tally(RCP_PL& pl, const std::vector<double>& z_edges)
 {
-  Require(d_assembly);
+  Expects(d_assembly);
   auto tally_pl = Teuchos::sublist(pl, "TALLY");
   auto cell_pl = Teuchos::sublist(tally_pl, "CELL");
 


### PR DESCRIPTION
@sphamil and I discussed stripping out external dependencies for the surrogate solvers that appear in the smrt directory. One of the changes needed is to use assertion macros from GSL (which is already in our repo) rather than the existing assertion macros that are being used (from SCALE). I've made the following changes:

- Precondition: `Requires` is now `Expects`
- General invariant: `Check` is now `Expects`
- Input validation: `Validate` is now `Expects` (had to remove error message, but we agreed this is not a big deal)
- Postcondition: `Ensure` is now `Ensures`

@sphamil Can you try compiling and make sure that I haven't broken anything?