### PR TITLE
HOST_NAME_MAX -> _POSIX_HOST_NAME_MAX

### DIFF
--- a/tests/comm_split_demo/main.cpp
+++ b/tests/comm_split_demo/main.cpp
@@ -84,8 +84,8 @@ int main(int argc, char* argv[])
   // Debug: Print which comms/ranks are on which host
   //===========================================================================
 
-  char myHostName[HOST_NAME_MAX];
-  gethostname(myHostName, HOST_NAME_MAX);
+  char myHostName[_POSIX_HOST_NAME_MAX];
+  gethostname(myHostName, _POSIX_HOST_NAME_MAX);
 
   for (int i = 0; i < world.size; i++) {
     if (world.rank == i)


### PR DESCRIPTION
Doesn't affect ENRICO core, but gives an error with "make all" on my MacBook.  This was the better macro to use, anyway.  