### PR TITLE
Move convergence check

### DIFF
--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -30,6 +30,11 @@ public:
   //! Execute the coupled driver
   virtual void execute();
 
+  //! Whether the calling rank has access to the coupled solution
+  //! fields for the heat source, temperature, density, and other protected member
+  //! variables of this class.
+  virtual bool has_global_coupling_data() const = 0;
+
   //! Update the heat source for the thermal-hydraulics solver
   virtual void update_heat_source() final;
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -43,8 +43,7 @@ public:
   virtual void update_density() {}
 
   //! Check convergence of the coupled solve for the current Picard iteration.
-  //! By default, derived classes will run up to the maximum number of Picard iterations.
-  virtual bool is_converged() { return false; }
+  virtual bool is_converged();
 
   enum class Norm { L1, L2, LINF }; //! Types of norms
 

--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -28,8 +28,6 @@ public:
 
   void update_temperature() override;
 
-  bool is_converged() override;
-
   NeutronicsDriver& get_neutronics_driver() const override;
 
   HeatFluidsDriver & get_heat_driver() const override;

--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -24,6 +24,12 @@ public:
   //! \param node  XML node containing settings
   explicit OpenmcHeatDriver(MPI_Comm comm, pugi::xml_node node);
 
+  //! Whether the calling rank has access to global coupling fields. Because OpenMC
+  //! and the surrogate driver share the same communicator, and the surrogate driver does not
+  //! split up its computation among multiple ranks, we only need to check that
+  //! both communicators are active (which they always should be).
+  bool has_global_coupling_data() const override;
+
   void set_heat_source() override;
 
   void update_temperature() override;

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -29,6 +29,14 @@ public:
   //! Frees any data structures that need manual freeing.
   ~OpenmcNekDriver();
 
+  //! Whether the calling rank has access to global coupling fields. Because the OpenMC
+  //! and Nek communicators are assumed to overlap (though they are not the same), and
+  //! Nek broadcasts its solution onto the OpenMC ranks, we need to check that both
+  //! communicators are active.
+  //!
+  //! TODO: This won't work if the OpenMC and Nek communicators are disjoint
+  bool has_global_coupling_data() const override;
+
   void set_heat_source() override;
 
   void update_temperature() override;

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -39,13 +39,6 @@ public:
 
   HeatFluidsDriver & get_heat_driver() const override;
 
-  //! Check convergence based on temperature field and specified epsilon
-  //!
-  //! Currently compares L_inf norm of temperature data between iterations
-  //!
-  //! \return true if L_inf norm of temperature data is less than epsilon
-  bool is_converged() override;
-
   Comm intranode_comm_; //!< The communicator representing intranode ranks
   std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
   std::unique_ptr<NekDriver> nek_driver_;       //!< The Nek5000 driver

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -3,7 +3,6 @@
 #include "enrico/driver.h"
 
 #include "gsl/gsl"
-#include "enrico/error.h"
 #include "xtensor/xnorm.hpp"
 
 namespace enrico {

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -28,6 +28,11 @@ OpenmcHeatDriver::OpenmcHeatDriver(MPI_Comm comm, pugi::xml_node node)
   init_heat_source();
 }
 
+bool OpenmcHeatDriver::has_global_coupling_data() const
+{
+  return openmc_driver_->active() && heat_driver_->active();
+}
+
 NeutronicsDriver& OpenmcHeatDriver::get_neutronics_driver() const
 {
   return *openmc_driver_;

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -165,9 +165,10 @@ void OpenmcHeatDriver::init_temperatures()
       }
     }
 
-  if (temperature_ic_ == Initial::heat) {
-    throw std::runtime_error{"Temperature initial conditions from surrogate heat-fluids "
-                             "solver not supported."};
+    if (temperature_ic_ == Initial::heat) {
+      throw std::runtime_error{"Temperature initial conditions from surrogate heat-fluids "
+                               "solver not supported."};
+    }
   }
 }
 

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -244,18 +244,4 @@ void OpenmcHeatDriver::update_temperature()
   }
 }
 
-bool OpenmcHeatDriver::is_converged()
-{
-  bool converged;
-  if (comm_.rank == 0) {
-    double norm;
-    compute_temperature_norm(Norm::LINF, norm, converged);
-
-    std::string msg = "temperature norm_linf: " + std::to_string(norm);
-    comm_.message(msg);
-  }
-  err_chk(comm_.Bcast(&converged, 1, MPI_CXX_BOOL));
-  return converged;
-}
-
 } // namespace enrico

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -102,8 +102,8 @@ void OpenmcNekDriver::init_mpi_datatypes()
 void OpenmcNekDriver::init_mappings()
 {
   if (this->has_global_coupling_data()) {
-    elem_centroids_.resize(n_global_elem_);
-    elem_fluid_mask_.resize(n_global_elem_);
+    elem_centroids_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
+    elem_fluid_mask_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
 
   if (nek_driver_->active()) {
@@ -246,7 +246,7 @@ void OpenmcNekDriver::init_temperatures()
 void OpenmcNekDriver::init_volumes()
 {
   if (this->has_global_coupling_data()) {
-    elem_volumes_.resize({n_global_elem_});
+    elem_volumes_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
 
   if (nek_driver_->active()) {
@@ -272,7 +272,7 @@ void OpenmcNekDriver::init_volumes()
 
 void OpenmcNekDriver::init_elem_densities()
 {
-  if (has_global_coupling_data()) {
+  if (this->has_global_coupling_data()) {
     elem_densities_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
   update_elem_densities();

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -101,14 +101,12 @@ void OpenmcNekDriver::init_mpi_datatypes()
 
 void OpenmcNekDriver::init_mappings()
 {
-  // TODO: This won't work if the Nek/OpenMC communicators are disjoint
+  if (this->has_global_coupling_data()) {
+    elem_centroids_.resize(n_global_elem_);
+    elem_fluid_mask_.resize(n_global_elem_);
+  }
 
   if (nek_driver_->active()) {
-    // Only the OpenMC procs get the global element centroids/fluid-identities
-    if (openmc_driver_->active()) {
-      elem_centroids_.resize(n_global_elem_);
-      elem_fluid_mask_.resize({n_global_elem_});
-    }
     // Step 1: Get global element centroids/fluid-identities on all OpenMC ranks
     // Each Nek proc finds the centroids/fluid-identities of its local elements
     Position local_element_centroids[n_local_elem_];
@@ -212,14 +210,11 @@ void OpenmcNekDriver::init_tallies()
 
 void OpenmcNekDriver::init_temperatures()
 {
-  if (nek_driver_->active() && openmc_driver_->active()) {
+  if (this->has_global_coupling_data()) {
     temperatures_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
     temperatures_prev_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
-  }
-  // TODO: This won't work if the Nek/OpenMC communicators are disjoint
-  // Only the OpenMC procs get the global temperatures
-  if (temperature_ic_ == Initial::neutronics) {
-    if (nek_driver_->active() && openmc_driver_->active()) {
+
+    if (temperature_ic_ == Initial::neutronics) {
       // Loop over the OpenMC cells, then loop over the global Nek elements
       // corresponding to that cell and assign the OpenMC cell temperature to
       // the correct index in the temperatures_ array. This mapping assumes that
@@ -250,13 +245,11 @@ void OpenmcNekDriver::init_temperatures()
 
 void OpenmcNekDriver::init_volumes()
 {
-  // TODO: This won't work if the Nek/OpenMC communicators are disjoint
+  if (this->has_global_coupling_data()) {
+    elem_volumes_.resize({n_global_elem_});
+  }
 
-  // Only the OpenMC procs get the global element volumes (gev)
   if (nek_driver_->active()) {
-    if (openmc_driver_->active()) {
-      elem_volumes_.resize({n_global_elem_});
-    }
     // Every Nek proc gets its local element volumes (lev)
     double local_elem_volumes[n_local_elem_];
     for (int i = 0; i < n_local_elem_; ++i) {
@@ -279,8 +272,7 @@ void OpenmcNekDriver::init_volumes()
 
 void OpenmcNekDriver::init_elem_densities()
 {
-  // TODO: This won't work if the Nek/OpenMC communicators are disjoint
-  if (nek_driver_->active() && openmc_driver_->active()) {
+  if (has_global_coupling_data()) {
     elem_densities_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
   update_elem_densities();
@@ -288,7 +280,7 @@ void OpenmcNekDriver::init_elem_densities()
 
 void OpenmcNekDriver::init_elem_fluid_mask()
 {
-  if (nek_driver_->active() && openmc_driver_->active()) {
+  if (this->has_global_coupling_data()) {
     elem_fluid_mask_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
   if (nek_driver_->active()) {
@@ -360,12 +352,11 @@ void OpenmcNekDriver::set_heat_source()
 
 void OpenmcNekDriver::update_temperature()
 {
-  if (nek_driver_->active()) {
-    // Copy previous
-    if (openmc_driver_->active()) {
-      std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
-    }
+  if (this->has_global_coupling_data()) {
+    std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
+  }
 
+  if (nek_driver_->active()) {
     auto t = nek_driver_->temperature();
     if (nek_driver_->comm_.rank == 0) {
       temperatures_ = t;

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -443,21 +443,6 @@ void OpenmcNekDriver::update_cell_densities()
   }
 }
 
-bool OpenmcNekDriver::is_converged()
-{
-  bool converged;
-  // WARNING: Assumes that OpenmcNekDriver rank 0 is in openmc_driver_->comm
-  if (comm_.rank == 0) {
-    double norm;
-    compute_temperature_norm(Norm::LINF, norm, converged);
-
-    std::string msg = "temperature norm_linf: " + std::to_string(norm);
-    comm_.message(msg);
-  }
-  err_chk(comm_.Bcast(&converged, 1, MPI_CXX_BOOL));
-  return converged;
-}
-
 void OpenmcNekDriver::free_mpi_datatypes()
 {
   MPI_Type_free(&position_mpi_datatype);

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -61,6 +61,11 @@ OpenmcNekDriver::~OpenmcNekDriver()
   free_mpi_datatypes();
 }
 
+bool OpenmcNekDriver::has_global_coupling_data() const
+{
+  return openmc_driver_->active() && nek_driver_->active();
+}
+
 NeutronicsDriver& OpenmcNekDriver::get_neutronics_driver() const
 {
   return *openmc_driver_;


### PR DESCRIPTION
Both `OpenmcHeatDriver` and `OpenmcNekDriver` implemented their own convergence checks, which were identical. This MR moves the convergence check to the `CoupledDriver` class. In addition, a `has_global_coupling_data()` method is added to ensure that the convergence check is only called from ranks that have access to the global coupling solution fields, since that might differ in the future between `OpenmcHeatDriver` and `OpenmcNekDriver`.