### PR TITLE
Smrt enrico consolidation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ if (SCALE_FOUND)
         src/smrt/Multi_Pin_Conduction.cpp
         src/smrt/Multi_Pin_Subchannel.cpp
         src/smrt/shift_driver.cpp
+        src/smrt/smrt_coupled_driver.cpp
         src/smrt/Single_Pin_Conduction.cpp
         src/smrt/Single_Pin_Subchannel.cpp
         src/smrt/Two_Group_Cross_Sections.cpp

--- a/include/enrico/message_passing.h
+++ b/include/enrico/message_passing.h
@@ -4,6 +4,7 @@
 #define ENRICO_MESSAGE_PASSING_H
 
 #include "mpi.h"
+#include "geom.h"
 
 //! The ENRICO namespace
 namespace enrico {
@@ -42,6 +43,10 @@ void get_node_comms(MPI_Comm super_comm,
                     int procs_per_node,
                     MPI_Comm* sub_comm,
                     MPI_Comm* intranode_comm);
+
+//! Define position MPI data type
+//! \return MPI position data type
+MPI_Datatype define_position_mpi_datatype();
 
 } // namespace enrico
 

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -24,7 +24,7 @@ public:
   //! perform any normalization. This method may also include unit conversions
   //! if necessary.
   //! \param heat_source Heat source to be normalized
-  //! \param power Total integrated power with which to normalize
+  //! \param power Total integrated power with which to normalize [W]
   virtual void normalize_heat_source(xt::xtensor<double, 1>& heat_source, double power) const {}
 };
 

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -19,6 +19,13 @@ public:
   //! \param power User-specified power in [W]
   //! \return Heat source in each material as [W/cm3]
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
+
+  //! Normalize the heat source by a given power. By default, this method does not
+  //! perform any normalization. This method may also include unit conversions
+  //! if necessary.
+  //! \param heat_source Heat source to be normalized
+  //! \param power Total integrated power with which to normalize
+  virtual void normalize_heat_source(xt::xtensor<double, 1>& heat_source, double power) const {}
 };
 
 } // namespace enrico

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -31,6 +31,8 @@ public:
 
   xt::xtensor<double, 1> heat_source(double power) const final;
 
+  void normalize_heat_source(xt::xtensor<double, 1>& heat_source, double power) const final;
+
   //! Initialization required in each Picard iteration
   void init_step() final;
 

--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -38,10 +38,6 @@ public:
 
   HeatFluidsDriver & get_heat_driver() const override;
 
-  std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
-
-  std::unique_ptr<SurrogateHeatDriver> heat_driver_; //!< The heat surrogate driver
-
   // Mapping of surrogate rings to OpenMC cell instances and vice versa
   std::unordered_map<int, std::vector<int>> ring_to_cell_inst_;
   std::unordered_map<int, std::vector<int>> cell_inst_to_ring_;
@@ -60,6 +56,10 @@ private:
 
   //! Initialize tallies in OpenMC
   void init_tallies();
+
+  std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
+
+  std::unique_ptr<SurrogateHeatDriver> heat_driver_; //!< The heat surrogate driver
 
   int32_t n_materials_; //! Number of materials in OpenMC model
 };

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -49,9 +49,9 @@ public:
   HeatFluidsDriver & get_heat_driver() const override;
 
   Comm intranode_comm_; //!< The communicator representing intranode ranks
-  std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
-  std::unique_ptr<NekDriver> nek_driver_;       //!< The Nek5000 driver
-  int openmc_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in OpenMC comm
+  double pressure_;                             //!< System pressure in [MPa]
+  int openmc_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in OpenMC
+                              //!< comm
 
 protected:
   //! Initialize global temperature buffers on all OpenMC ranks.
@@ -103,6 +103,10 @@ private:
 
   //! Updates cell_densities_ from elem_densities_.
   void update_cell_densities();
+
+  std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
+
+  std::unique_ptr<NekDriver> nek_driver_;       //!< The Nek5000 driver
 
   //! MPI datatype for sending/receiving Position objects.
   MPI_Datatype position_mpi_datatype;

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -49,7 +49,6 @@ public:
   HeatFluidsDriver & get_heat_driver() const override;
 
   Comm intranode_comm_; //!< The communicator representing intranode ranks
-  double pressure_;                             //!< System pressure in [MPa]
   int openmc_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in OpenMC
                               //!< comm
 

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -6,6 +6,7 @@
 #include "enrico/coupled_driver.h"
 #include "enrico/nek_driver.h"
 #include "enrico/openmc_driver.h"
+#include "enrico/message_passing.h"
 #include "mpi.h"
 
 #include <unordered_set>

--- a/include/smrt/Neutronics_Solver.h
+++ b/include/smrt/Neutronics_Solver.h
@@ -29,6 +29,9 @@ public:
   virtual void solve(const Vec_Dbl& fuel_temperature,
                      const Vec_Dbl& coolant_density,
                      Vec_Dbl& power) = 0;
+
+  // Update the temperature used in the neutronics solver
+  virtual void update_temperature(const std::vector<double>& temperatures) {}
 };
 
 //---------------------------------------------------------------------------//

--- a/include/smrt/Neutronics_Solver.h
+++ b/include/smrt/Neutronics_Solver.h
@@ -32,6 +32,9 @@ public:
 
   // Update the temperature used in the neutronics solver
   virtual void update_temperature(const std::vector<double>& temperatures) {}
+
+  // Update the density used in the neutronics solver
+  virtual void update_density(const std::vector<double>& densities) {}
 };
 
 //---------------------------------------------------------------------------//

--- a/include/smrt/shift_driver.h
+++ b/include/smrt/shift_driver.h
@@ -40,6 +40,8 @@ public:
   using RCP_PL = Teuchos::RCP<Teuchos::ParameterList>;
   //@}
 
+  void update_temperature(const std::vector<double>& temperatures) override;
+
 private:
   // >>> DATA
   SP_Assembly_Model d_assembly;

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -11,6 +11,7 @@
 #include "enrico/error.h"
 #include "enrico/message_passing.h"
 #include "enrico/nek_driver.h"
+#include "smrt_coupled_driver.h"
 #include "nek5000/core/nek_interface.h"
 
 namespace enrico {
@@ -23,7 +24,7 @@ namespace enrico {
  * coupled nonlinear system.
  */
 //===========================================================================//
-class ShiftNekDriver {
+class ShiftNekDriver : public SmrtCoupledDriver {
 public:
   //! Power in [W]
   double power_;

--- a/include/smrt/smrt_coupled_driver.h
+++ b/include/smrt/smrt_coupled_driver.h
@@ -1,0 +1,22 @@
+#ifndef SMRT_COUPLED_DRIVER_H
+#define SMRT_COUPLED_DRIVER_H
+
+namespace enrico {
+
+/**
+ * Base class for driver that controls a coupled physics solve involving
+ * neutronics and thermal-hydraulics physics. This is intended to be a
+ * temporary class to aid in incrementally moving the ShiftNekDriver to be
+ * a derived class of CoupledDriver, so most of the methods in this class
+ * are created to be similar to CoupledDriver.
+ */
+class SmrtCoupledDriver {
+public:
+  SmrtCoupledDriver() = default;
+};
+
+//---------------------------------------------------------------------------//
+} // end namespace enrico
+
+#endif // SMRT_COUPLED_DRIVER_H
+

--- a/include/smrt/smrt_coupled_driver.h
+++ b/include/smrt/smrt_coupled_driver.h
@@ -12,7 +12,11 @@ namespace enrico {
  */
 class SmrtCoupledDriver {
 public:
-  SmrtCoupledDriver() = default;
+  SmrtCoupledDriver();
+
+  double power_; //!< Power in [W]
+
+  int max_picard_iter_; //!< Maximum number of Picard iterations
 };
 
 //---------------------------------------------------------------------------//

--- a/src/message_passing.cpp
+++ b/src/message_passing.cpp
@@ -32,7 +32,6 @@ void get_node_comms(MPI_Comm super_comm,
 
 MPI_Datatype define_position_mpi_datatype()
 {
-  MPI_Datatype type;
 
   Position p;
   int blockcounts[3] = {1, 1, 1};
@@ -50,6 +49,7 @@ MPI_Datatype define_position_mpi_datatype()
   displs[0] = 0;
 
   // Make datatype
+  MPI_Datatype type;
   MPI_Type_create_struct(3, blockcounts, displs, types, &type);
   MPI_Type_commit(&type);
 

--- a/src/message_passing.cpp
+++ b/src/message_passing.cpp
@@ -30,4 +30,30 @@ void get_node_comms(MPI_Comm super_comm,
     MPI_Comm_free(sub_comm);
 }
 
+MPI_Datatype define_position_mpi_datatype()
+{
+  MPI_Datatype type;
+
+  Position p;
+  int blockcounts[3] = {1, 1, 1};
+  MPI_Datatype types[3] = {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE};
+  MPI_Aint displs[3];
+
+  // Get displacements of struct members
+  MPI_Get_address(&p.x, &displs[0]);
+  MPI_Get_address(&p.y, &displs[1]);
+  MPI_Get_address(&p.z, &displs[2]);
+
+  // Make the displacements relative
+  displs[2] -= displs[0];
+  displs[1] -= displs[0];
+  displs[0] = 0;
+
+  // Make datatype
+  MPI_Type_create_struct(3, blockcounts, displs, types, &type);
+  MPI_Type_commit(&type);
+
+  return type;
+}
+
 } // namespace enrico

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -60,10 +60,17 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
   auto mean_value = xt::view(tally_->results_, xt::all(), 0, openmc::RESULT_SUM);
   xt::xtensor<double, 1> heat = JOULE_PER_EV * mean_value / m;
 
-  // Get total heat production [J/source]
-  double total_heat = xt::sum(heat)();
+  // Normalize the heat source
+  normalize_heat_source(heat, power);
 
-  // Normalize heat source in each material and collect in an array
+  return heat;
+}
+
+void OpenmcDriver::normalize_heat_source(xt::xtensor<double, 1>& heat_source, double power) const
+{
+  // Get total heat production [J/source]
+  double total_heat = xt::sum(heat_source)();
+
   for (int i = 0; i < cells_.size(); ++i) {
     // Get volume
     double V = cells_.at(i).volume_;
@@ -71,10 +78,8 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
     // Convert heat from [J/source] to [W/cm^3]. Dividing by total_heat gives
     // the fraction of heat deposited in each material. Multiplying by power
     // givens an absolute value in W
-    heat(i) *= power / (total_heat * V);
+    heat_source(i) *= power / (total_heat * V);
   }
-
-  return heat;
 }
 
 void OpenmcDriver::init_step()

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -79,25 +79,6 @@ HeatFluidsDriver& OpenmcNekDriver::get_heat_driver() const
 void OpenmcNekDriver::init_mpi_datatypes()
 {
   position_mpi_datatype = define_position_mpi_datatype();
-  //// Currently, this sets up only position_mpi_datatype
-  //Position p;
-  //int blockcounts[3] = {1, 1, 1};
-  //MPI_Datatype types[3] = {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE};
-  //MPI_Aint displs[3];
-
-  //// Get displacements of struct members
-  //MPI_Get_address(&p.x, &displs[0]);
-  //MPI_Get_address(&p.y, &displs[1]);
-  //MPI_Get_address(&p.z, &displs[2]);
-
-  //// Make the displacements relative
-  //displs[2] -= displs[0];
-  //displs[1] -= displs[0];
-  //displs[0] = 0;
-
-  //// Make datatype
-  //MPI_Type_create_struct(3, blockcounts, displs, types, &position_mpi_datatype);
-  //MPI_Type_commit(&position_mpi_datatype);
 }
 
 void OpenmcNekDriver::init_mappings()

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -78,25 +78,26 @@ HeatFluidsDriver& OpenmcNekDriver::get_heat_driver() const
 
 void OpenmcNekDriver::init_mpi_datatypes()
 {
-  // Currently, this sets up only position_mpi_datatype
-  Position p;
-  int blockcounts[3] = {1, 1, 1};
-  MPI_Datatype types[3] = {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE};
-  MPI_Aint displs[3];
+  position_mpi_datatype = define_position_mpi_datatype();
+  //// Currently, this sets up only position_mpi_datatype
+  //Position p;
+  //int blockcounts[3] = {1, 1, 1};
+  //MPI_Datatype types[3] = {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE};
+  //MPI_Aint displs[3];
 
-  // Get displacements of struct members
-  MPI_Get_address(&p.x, &displs[0]);
-  MPI_Get_address(&p.y, &displs[1]);
-  MPI_Get_address(&p.z, &displs[2]);
+  //// Get displacements of struct members
+  //MPI_Get_address(&p.x, &displs[0]);
+  //MPI_Get_address(&p.y, &displs[1]);
+  //MPI_Get_address(&p.z, &displs[2]);
 
-  // Make the displacements relative
-  displs[2] -= displs[0];
-  displs[1] -= displs[0];
-  displs[0] = 0;
+  //// Make the displacements relative
+  //displs[2] -= displs[0];
+  //displs[1] -= displs[0];
+  //displs[0] = 0;
 
-  // Make datatype
-  MPI_Type_create_struct(3, blockcounts, displs, types, &position_mpi_datatype);
-  MPI_Type_commit(&position_mpi_datatype);
+  //// Make datatype
+  //MPI_Type_create_struct(3, blockcounts, displs, types, &position_mpi_datatype);
+  //MPI_Type_commit(&position_mpi_datatype);
 }
 
 void OpenmcNekDriver::init_mappings()

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -68,6 +68,9 @@ void ShiftDriver::solve(const std::vector<double>& th_temperature,
 {
   update_temperature(th_temperature);
 
+  // currently does nothing
+  update_density(coolant_density);
+
   // Rebuild problem (loading any new data needed and run transport
   d_driver->rebuild();
   d_driver->run();

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -167,24 +167,7 @@ void ShiftNekDriver::normalize_power()
 // Currently, this sets up only position_mpi_datatype
 void ShiftNekDriver::init_mpi_datatypes()
 {
-  Position p;
-  int blockcounts[3] = {1, 1, 1};
-  MPI_Datatype types[3] = {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE};
-  MPI_Aint displs[3];
-
-  // Get displacements of struct members
-  MPI_Get_address(&p.x, &displs[0]);
-  MPI_Get_address(&p.y, &displs[1]);
-  MPI_Get_address(&p.z, &displs[2]);
-
-  // Make the displacements relative
-  displs[2] -= displs[0];
-  displs[1] -= displs[0];
-  displs[0] = 0;
-
-  // Make datatype
-  MPI_Type_create_struct(3, blockcounts, displs, types, &d_position_mpi_type);
-  MPI_Type_commit(&d_position_mpi_type);
+  d_position_mpi_type = define_position_mpi_type();
 }
 
 // Free user-defined MPI types

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -12,7 +12,8 @@ ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
                                const std::vector<double>& z_edges,
                                const std::string& shift_filename,
                                MPI_Comm neutronics_comm,
-                               MPI_Comm th_comm)
+                               MPI_Comm th_comm) :
+  SmrtCoupledDriver()
 {
   d_shift_solver =
     std::make_shared<enrico::ShiftDriver>(assembly, shift_filename, z_edges);

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -29,11 +29,6 @@ ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
 
     // Get root element
     auto root = doc.document_element();
-
-    // TODO: Belongs to CoupledDriver base class
-    power_ = root.child("power").text().as_double();
-    max_picard_iter_ = root.child("max_picard_iter").text().as_int();
-
     double pressure_bc = root.child("pressure_bc").text().as_double();
 
     d_nek_solver = std::make_shared<NekDriver>(

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -163,7 +163,7 @@ void ShiftNekDriver::normalize_power()
 // Currently, this sets up only position_mpi_datatype
 void ShiftNekDriver::init_mpi_datatypes()
 {
-  d_position_mpi_type = define_position_mpi_type();
+  d_position_mpi_type = define_position_mpi_datatype();
 }
 
 // Free user-defined MPI types

--- a/src/smrt/smrt_coupled_driver.cpp
+++ b/src/smrt/smrt_coupled_driver.cpp
@@ -1,0 +1,21 @@
+#include "smrt/smrt_coupled_driver.h"
+
+namespace enrico {
+
+SmrtCoupledDriver::SmrtCoupledDriver()
+{
+  // TODO: Belongs to main.cpp
+  pugi::xml_document doc;
+  auto result = doc.load_file("enrico.xml");
+  if (!result) {
+    throw std::runtime_error{"Unable to load enrico.xml file"};
+  }
+
+  // Get root element
+  auto root = doc.document_element();
+
+  power_ = root.child("power").text().as_double();
+  max_picard_iter_ = root.child("max_picard_iter").text().as_int();
+}
+
+} // end namespace enrico

--- a/src/smrt/smrt_coupled_driver.cpp
+++ b/src/smrt/smrt_coupled_driver.cpp
@@ -1,4 +1,6 @@
 #include "smrt/smrt_coupled_driver.h"
+#include "pugixml.hpp"
+#include <stdexcept>
 
 namespace enrico {
 


### PR DESCRIPTION
This PR has a couple first steps in eventually having `ShiftNekDriver` derive from `CoupledDriver`. This PR adds:

1. Mostly empty `SmrtCoupledDriver` class to assist in incremental updates to `ShiftNekDriver` so that we will eventually be able to replace `SmrtCoupledDriver` by `CoupledDriver`.

2. Split out some actions from the `solve` methods of `smrt` classes into more specific, smaller tasks.

3. Moved the definition of the position MPI datatype to `message_passing.h` since it's used equivalently by `ShiftNekDriver` and `OpenmcNekDriver`.

@sphamil would you please verify that this compiles? Hopefully I didn't leave any typos...