### PR TITLE
Move pressure to Nek node. Refs #15

### DIFF
--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -115,6 +115,8 @@ public:
   int nelgt_;            //!< total number of mesh elements
   int nelt_;             //!< number of local mesh elements
 
+  double pressure_; //! System pressure in [MPa]
+
   //! The number of local elements in each rank.
   std::vector<int> local_displs_;
 

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -49,7 +49,6 @@ public:
   Comm intranode_comm_; //!< The communicator representing intranode ranks
   std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
   std::unique_ptr<NekDriver> nek_driver_;       //!< The Nek5000 driver
-  double pressure_;                             //!< System pressure in [MPa]
   int openmc_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in OpenMC
                               //!< comm
 

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -15,9 +15,12 @@ namespace enrico {
 NekDriver::NekDriver(MPI_Comm comm, pugi::xml_node node)
   : Driver(comm)
 {
+  pressure_ = node.child("pressure").text().as_double();
   lelg_ = nek_get_lelg();
   lelt_ = nek_get_lelt();
   lx1_ = nek_get_lx1();
+
+  Expects(pressure_ > 0.0);
 
   if (active()) {
     casename_ = node.child_value("casename");

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -21,11 +21,9 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
 {
   // Get parameters from enrico.xml
   pugi::xml_node nek_node = node.child("nek5000");
-  pressure_ = node.child("pressure").text().as_double();
   openmc_procs_per_node_ = node.child("openmc_procs_per_node").text().as_int();
 
   // Postcondition checks on user inputs
-  Expects(pressure_ > 0.0);
   Expects(openmc_procs_per_node_ > 0);
 
   // Create communicator for OpenMC with requested processes per node
@@ -376,7 +374,7 @@ void OpenmcNekDriver::update_density()
 
           if (any_in_fluid) {
             // nu1 returns specific volume in [m^3/kg]
-            double density = 1.0e-3 / iapws::nu1(pressure_, T);
+            double density = 1.0e-3 / iapws::nu1(nek_driver_->pressure_, T);
             average_density += density * V;
             total_vol += V;
           }

--- a/tests/singlerod/long/openmc_nek5000/enrico.xml
+++ b/tests/singlerod/long/openmc_nek5000/enrico.xml
@@ -4,10 +4,10 @@
   <driver_heatfluids>nek5000</driver_heatfluids>
   <nek5000>
     <casename>rod_l</casename>
+    <pressure>12.7553</pressure>
   </nek5000>
   <communication>overlapping</communication>
   <power>16.4e3</power>
-  <pressure>12.7553</pressure>
   <max_timesteps>1</max_timesteps>
   <max_picard_iter>4</max_picard_iter>
   <openmc_procs_per_node>1</openmc_procs_per_node>

--- a/tests/singlerod/short/openmc_nek5000/enrico.xml
+++ b/tests/singlerod/short/openmc_nek5000/enrico.xml
@@ -4,10 +4,10 @@
   <driver_heatfluids>nek5000</driver_heatfluids>
   <nek5000>
     <casename>rodcht</casename>
+    <pressure>12.7553</pressure>
   </nek5000>
   <communication>overlapping</communication>
   <power>820.0</power>
-  <pressure>12.7553</pressure>
   <max_timesteps>4</max_timesteps>
   <max_picard_iter>2</max_picard_iter>
   <openmc_procs_per_node>1</openmc_procs_per_node>


### PR DESCRIPTION
This MR moves `pressure` to the Nek node since it is the only tool that requires pressure. If we add subchannel capabilities to `SurrogateHeatDriver`, we can move pressure back up.