### PR TITLE
Consolidate picard stepping loop in ShiftNekDriver with CoupledDriver

### DIFF
--- a/include/smrt/shift_driver.h
+++ b/include/smrt/shift_driver.h
@@ -73,8 +73,7 @@ public:
                                  const std::vector<double>& volumes);
 
   // Solve for new power distribution given temperatures and densities
-  void solve(const std::vector<double>& coolant_density,
-             std::vector<double>& power) override;
+  void solve(std::vector<double>& power) override;
 
 private:
   // Add power tally to parameter list

--- a/include/smrt/shift_driver.h
+++ b/include/smrt/shift_driver.h
@@ -73,8 +73,7 @@ public:
                                  const std::vector<double>& volumes);
 
   // Solve for new power distribution given temperatures and densities
-  void solve(const std::vector<double>& th_temperature,
-             const std::vector<double>& coolant_density,
+  void solve(const std::vector<double>& coolant_density,
              std::vector<double>& power) override;
 
 private:

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -26,6 +26,9 @@ namespace enrico {
 //===========================================================================//
 class ShiftNekDriver : public SmrtCoupledDriver {
 public:
+  //! Set the heat source in the thermal-hydraulics solver
+  void set_heat_source() override;
+
   //! Power in [W]
   double power_;
 

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -30,6 +30,8 @@ public:
 
   void update_temperature() override;
 
+  void update_density() override;
+
   Neutronics_Solver& get_neutronics_driver() const override;
 
   HeatFluidsDriver& get_heat_driver() const override;

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -26,8 +26,9 @@ namespace enrico {
 //===========================================================================//
 class ShiftNekDriver : public SmrtCoupledDriver {
 public:
-  //! Set the heat source in the thermal-hydraulics solver
   void set_heat_source() override;
+
+  void update_temperature() override;
 
   Neutronics_Solver& get_neutronics_driver() const override;
 

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -29,6 +29,10 @@ public:
   //! Set the heat source in the thermal-hydraulics solver
   void set_heat_source() override;
 
+  Neutronics_Solver& get_neutronics_driver() const override;
+
+  HeatFluidsDriver& get_heat_driver() const override;
+
   //! Power in [W]
   double power_;
 

--- a/include/smrt/smrt_coupled_driver.h
+++ b/include/smrt/smrt_coupled_driver.h
@@ -28,6 +28,12 @@ public:
   //! Set the heat source in the thermal-hydraulics solver
   virtual void set_heat_source() {};
 
+  //! Update the temperature for the neutronics solver
+  virtual void update_temperature() {}
+
+  //! Update the density for the neutronics solver
+  virtual void update_density() {}
+
   double power_; //!< Power in [W]
 
   int max_picard_iter_; //!< Maximum number of Picard iterations

--- a/include/smrt/smrt_coupled_driver.h
+++ b/include/smrt/smrt_coupled_driver.h
@@ -14,6 +14,9 @@ class SmrtCoupledDriver {
 public:
   SmrtCoupledDriver();
 
+  //! Set the heat source in the thermal-hydraulics solver
+  virtual void set_heat_source() {};
+
   double power_; //!< Power in [W]
 
   int max_picard_iter_; //!< Maximum number of Picard iterations

--- a/include/smrt/smrt_coupled_driver.h
+++ b/include/smrt/smrt_coupled_driver.h
@@ -1,6 +1,9 @@
 #ifndef SMRT_COUPLED_DRIVER_H
 #define SMRT_COUPLED_DRIVER_H
 
+#include "Neutronics_Solver.h"
+#include "enrico/heat_fluids_driver.h"
+
 namespace enrico {
 
 /**
@@ -13,6 +16,14 @@ namespace enrico {
 class SmrtCoupledDriver {
 public:
   SmrtCoupledDriver();
+
+  //! Get reference to neutronics driver
+  //! \return reference to driver
+  Neutronics_Solver& get_neutronics_driver() const = 0;
+
+  //! Get reference to thermal-fluids driver
+  //! \return reference to driver
+  HeatFluidsDriver& get_heat_driver() const = 0;
 
   //! Set the heat source in the thermal-hydraulics solver
   virtual void set_heat_source() {};

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -62,12 +62,9 @@ ShiftDriver::ShiftDriver(SP_Assembly_Model assembly,
 //---------------------------------------------------------------------------//
 // Solve
 //---------------------------------------------------------------------------//
-void ShiftDriver::solve(const std::vector<double>& th_temperature,
-                        const std::vector<double>& coolant_density,
-                        std::vector<double>& power)
+void ShiftDriver::solve(const std::vector<double>& coolant_density,
+                         std::vector<double>& power)
 {
-  update_temperature(th_temperature);
-
   // currently does nothing
   update_density(coolant_density);
 

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -62,12 +62,8 @@ ShiftDriver::ShiftDriver(SP_Assembly_Model assembly,
 //---------------------------------------------------------------------------//
 // Solve
 //---------------------------------------------------------------------------//
-void ShiftDriver::solve(const std::vector<double>& coolant_density,
-                         std::vector<double>& power)
+void ShiftDriver::solve(std::vector<double>& power)
 {
-  // currently does nothing
-  update_density(coolant_density);
-
   // Rebuild problem (loading any new data needed and run transport
   d_driver->rebuild();
   d_driver->run();

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -130,6 +130,11 @@ void ShiftNekDriver::update_temperature()
   d_shift_solver->update_temperature(d_temperatures);
 }
 
+void ShiftNekDriver::update_density()
+{
+  d_shift_solver->update_density(d_densities);
+}
+
 // Solve coupled problem by iterating between neutronics and T/H
 void ShiftNekDriver::solve()
 {
@@ -150,7 +155,7 @@ void ShiftNekDriver::solve()
     update_density();
 
     // Solve Shift problem
-    neutronics.solve(d_densities, d_powers);
+    neutronics.solve(d_powers);
 
     // Apply power normalization
     normalize_power();

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -139,6 +139,9 @@ void ShiftNekDriver::solve()
       nemesis::global_barrier();
     }
 
+    update_temperature();
+    update_density();
+
     // Solve Shift problem
     neutronics.solve(d_temperatures, d_densities, d_powers);
 

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -85,8 +85,10 @@ ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
   }
 }
 
-// Destructor
-ShiftNekDriver::~ShiftNekDriver() {}
+ShiftNekDriver::~ShiftNekDriver()
+{
+  free_mpi_datatypes();
+}
 
 Neutronics_Solver& get_neutronics_driver() const
 {
@@ -170,8 +172,6 @@ void ShiftNekDriver::solve()
       nemesis::global_barrier();
     }
   }
-
-  this->free_mpi_datatypes();
 }
 
 //

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -106,6 +106,12 @@ void ShiftNekDriver::set_heat_source()
   }
 }
 
+void ShiftNekDriver::update_temperature()
+{
+  auto& neutronics = get_neutronics_driver();
+  neutronics.update_temperature(d_temperatures);
+}
+
 // Solve coupled problem by iterating between neutronics and T/H
 void ShiftNekDriver::solve()
 {
@@ -143,7 +149,7 @@ void ShiftNekDriver::solve()
     update_density();
 
     // Solve Shift problem
-    neutronics.solve(d_temperatures, d_densities, d_powers);
+    neutronics.solve(d_densities, d_powers);
 
     // Apply power normalization
     normalize_power();

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -88,16 +88,22 @@ ShiftNekDriver::ShiftNekDriver(std::shared_ptr<Assembly_Model> assembly,
 // Destructor
 ShiftNekDriver::~ShiftNekDriver() {}
 
+void ShiftNekDriver::set_heat_source()
+{
+  for (int elem = 0; elem < d_th_num_local; ++elem) {
+    err_chk(d_nek_solver->set_heat_source_at(elem + 1, d_powers[elem]),
+            "Error setting heat source for local element " + std::to_string(elem + 1));
+  }
+}
+
 // Solve coupled problem by iterating between neutronics and T/H
 void ShiftNekDriver::solve()
 {
   // Loop to convergence or fixed iteration count
   for (int iteration = 0; iteration < max_picard_iter_; ++iteration) {
+
     // Set heat source in Nek
-    for (int elem = 0; elem < d_th_num_local; ++elem) {
-      err_chk(d_nek_solver->set_heat_source_at(elem + 1, d_powers[elem]),
-              "Error setting heat source for local element " + std::to_string(elem + 1));
-    }
+    set_heat_source();
 
     // Solve Nek problem
     d_nek_solver->solve_step();


### PR DESCRIPTION
This MR consolidates most of the unique features of `ShiftNekDriver` to merge with `CoupledDriver` so that `ShiftNekDriver` can eventually inherit from `CoupledDriver` instead of `SmrtCoupledDriver`. The following methods were added:

1. `ShiftNekDriver::set_heat_source()`, which moves the setting of heat source in Nek out of `solve()` 
2. `ShiftNekDriver::get_neutronics_driver()` and `ShiftNekDriver::get_heat_driver()` for similarity to `CoupledDriver`
3. `ShiftNekDriver::update_temperature()` and `ShiftNekDriver::update_density()` to remove those actions from the `ShiftDriver::solve(..)`  method

This MR is marked as WIP until #30 is merged in, since this relies on some of those commits.