### PR TITLE
Set density IC in OpenmcNekDriver

### DIFF
--- a/doc/source/input.rst
+++ b/doc/source/input.rst
@@ -71,6 +71,19 @@ heat-fluids solver.
 
 *Default*: neutronics
 
+``<density_ic>``
+--------------------
+
+The initial density distribution can be determined either from the
+neutronics solver or the heat-fluids solver. A value of "neutronics" will use
+the densities specified in the model for the neutronics solver whereas a
+value of "heat" will use the densities specified in the model for the
+heat-fluids solver. Note that this density initial condition strictly refers
+to the fluid density - the solid density is constant throughout the simulation,
+and is unchanged from the value used in the neutronics input.
+
+*Default*: neutronics
+
 ``<pressure_bc>``
 --------------
 

--- a/include/enrico/cell_instance.h
+++ b/include/enrico/cell_instance.h
@@ -34,6 +34,10 @@ public:
   //! \return cell temperature in [K]
   double get_temperature() const;
 
+  //! Get the density of this cell
+  //! \return cell density in [g/cm^3]
+  double get_density() const;
+
   //! Check for equality
   bool operator==(const CellInstance& other) const;
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -103,6 +103,10 @@ public:
   //! temperatures in the neutronics input file.
   Initial temperature_ic_{Initial::neutronics};
 
+  //! Where to obtain the density initial condition from. Defaults to the densities
+  //! in the neutronics input file.
+  Initial density_ic_{Initial::neutronics};
+
 protected:
   //! Initialize current and previous Picard temperature fields
   virtual void init_temperatures() {}

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -107,6 +107,9 @@ protected:
   //! Initialize current and previous Picard temperature fields
   virtual void init_temperatures() {}
 
+  //! Initialize current and previous Picard density fields
+  virtual void init_densities() {}
+
   //! Initialize current and previous Picard heat source fields. Note that
   //! because the neutronics solver is assumed to run first, that no initial
   //! condition is required for the heat source. So, unlike init_temperatures(),
@@ -121,6 +124,15 @@ protected:
   xt::xtensor<double, 1> temperatures_;
 
   xt::xtensor<double, 1> temperatures_prev_; //!< Previous Picard iteration temperature
+
+  //! Current Picard iteration density; this density is the density
+  //! computed by the thermal-hydraulic solver, and data mappings may result in
+  //! a different density actually used in the neutronics solver. For example,
+  //! the entries in this xtensor may be averaged over neutronics cells to give
+  //! the density used by the neutronics solver.
+  xt::xtensor<double, 1> densities_;
+
+  xt::xtensor<double, 1> densities_prev_; //!< Previous Picard iteration density
 
   //! Current Picard iteration heat source; this heat source is the heat source
   //! computed by the neutronics solver, and data mappings may result in a different

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -113,11 +113,21 @@ protected:
   //! this method does not set any initial values.
   virtual void init_heat_source() {}
 
-  xt::xtensor<double, 1> temperatures_; //!< Current Picard iteration temperature
+  //! Current Picard iteration temperature; this temperature is the temperature
+  //! computed by the thermal-hydraulic solver, and data mappings may result in
+  //! a different temperature actually used in the neutronics solver. For example,
+  //! the entries in this xtensor may be averaged over neutronics cells to give
+  //! the temperature used by the neutronics solver.
+  xt::xtensor<double, 1> temperatures_;
 
   xt::xtensor<double, 1> temperatures_prev_; //!< Previous Picard iteration temperature
 
-  xt::xtensor<double, 1> heat_source_; //!< Current Picard iteration heat source
+  //! Current Picard iteration heat source; this heat source is the heat source
+  //! computed by the neutronics solver, and data mappings may result in a different
+  //! heat source actually used in the heat solver. For example, the entries in this
+  //! xtensor may be averaged over thermal-hydraulics cells to give the heat source
+  //! used by the thermal-hydraulics solver.
+  xt::xtensor<double, 1> heat_source_;
 
   xt::xtensor<double, 1> heat_source_prev_; //!< Previous Picard iteration heat source
 

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -125,11 +125,6 @@ private:
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
   xt::xtensor<double, 1> elem_volumes_;
 
-  //! The dimensionless densities of Nek's global elements
-  //! These are **not** ordered by Nek's global element indices.  Rather, these are
-  //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
-  xt::xtensor<double, 1> elem_densities_;
-
   //! Map that gives a list of Nek element global indices for a given OpenMC material
   //! index. The Nek global element indices refer to indices defined by the MPI_Gatherv
   //! operation, and do not reflect Nek's internal global element indexing.

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -67,6 +67,13 @@ protected:
   //! to an MPI_Gatherv operation on Nek5000's local elements.
   void init_heat_source() override;
 
+  //! Initialize global density buffers on all OpenMC ranks.
+  //!
+  //! These arrays store the ensity of Nek's global elements. These are **not**
+  //! ordered by Nek's global element indices. Rather, these are ordered according
+  //! to an MPI_Gatherv operation on Nek5000's local elements.
+  void init_densities() override;
+
   //! Initialize global fluid masks on all OpenMC ranks.
   //!
   //! These arrays store the dimensionless source of Nek's global elements. These are **not**
@@ -90,18 +97,8 @@ private:
   //! Initialize global volume buffers for OpenMC ranks
   void init_volumes();
 
-  //! Allocate space for the global volume buffers in OpenMC ranks
-  //! Currently, the density values are uninitialized.
-  void init_elem_densities();
-
   //! Frees the MPI datatypes (currently, only position_mpi_datatype)
   void free_mpi_datatypes();
-
-  //! Updates elem_densities_ from Nek5000's density data
-  void update_elem_densities();
-
-  //! Updates cell_densities_ from elem_densities_.
-  void update_cell_densities();
 
   std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
 

--- a/src/cell_instance.cpp
+++ b/src/cell_instance.cpp
@@ -53,6 +53,13 @@ void CellInstance::set_density(double rho) const
   err_chk(openmc_material_set_density(material_index_, rho, "g/cm3"));
 }
 
+double CellInstance::get_density() const
+{
+  double rho;
+  err_chk(openmc_material_get_density(material_index));
+  return rho;
+}
+
 bool CellInstance::operator==(const CellInstance& other) const
 {
   return index_ == other.index_ && instance_ == other.instance_;

--- a/src/cell_instance.cpp
+++ b/src/cell_instance.cpp
@@ -56,7 +56,7 @@ void CellInstance::set_density(double rho) const
 double CellInstance::get_density() const
 {
   double rho;
-  err_chk(openmc_material_get_density(material_index));
+  err_chk(openmc_material_get_density(material_index_, &rho));
   return rho;
 }
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -34,6 +34,18 @@ CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
     }
   }
 
+  if (node.child("density_ic")) {
+    auto s = std::string{node.child_value("density_ic")};
+
+    if (s == "neutronics") {
+      density_ic_ = Initial::neutronics;
+    } else if (s == "heat") {
+      density_ic_ = Initial::heat;
+    } else {
+      throw std::runtime_error{"Invalid value for <density_ic>"};
+    }
+  }
+
   Expects(power_ > 0);
   Expects(max_timesteps_ >= 0);
   Expects(max_picard_iter_ >= 0);

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -211,17 +211,17 @@ void OpenmcNekDriver::init_temperatures()
           temperatures_prev_[elem] = T;
         }
       }
-    }
-  } else if (temperature_ic_ == Initial::heat) {
-    // Use whatever temperature is in Nek's internal arrays, either from a restart
-    // file or from a useric fortran routine.
-    update_temperature();
+    } else if (temperature_ic_ == Initial::heat) {
+      // Use whatever temperature is in Nek's internal arrays, either from a restart
+      // file or from a useric fortran routine.
+      update_temperature();
 
-    // update_temperature() begins by saving temperatures_ to temperatures_prev_, and
-    // then changes temperatures_. We need to save temperatures_ here to
-    // temperatures_prev_ manually because init_temperatures() initializes both
-    // temperatures_ and temperatures_prev_.
-    std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
+      // update_temperature() begins by saving temperatures_ to temperatures_prev_, and
+      // then changes temperatures_. We need to save temperatures_ here to
+      // temperatures_prev_ manually because init_temperatures() initializes both
+      // temperatures_ and temperatures_prev_.
+      std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
+    }
   }
 }
 

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -265,15 +265,20 @@ void OpenmcNekDriver::init_densities()
       // each Nek element is fully contained within an OpenMC cell, i.e. Nek
       // elements are not split between multiple OpenMC cells.
       for (int i = 0; i < openmc_driver_->cells_.size(); ++i) {
-        if (cell_fluid_mask_[i] == 1) {
-          auto& c = openmc_driver_->cells_[i];
-          const auto& global_elems = mat_to_elems_.at(c.material_index_);
+        auto& c = openmc_driver_->cells_[i];
+        const auto& global_elems = mat_to_elems_.at(c.material_index_);
 
+        if (cell_fluid_mask_[i] == 1) {
           for (int elem: global_elems) {
             double rho = c.get_density();
             densities_[elem] = rho;
             densities_prev_[elem] = rho;
           }
+        } else {
+            for (int elem: global_elems) {
+              densities_[elem] = 0.0;
+              densities_prev_[elem] = 0.0;
+            }
         }
       }
     }

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -264,13 +264,16 @@ void OpenmcNekDriver::init_densities()
       // the correct index in the densities_ array. This mapping assumes that
       // each Nek element is fully contained within an OpenMC cell, i.e. Nek
       // elements are not split between multiple OpenMC cells.
-      for (const auto& c: openmc_driver_->cells_) {
-        const auto& global_elems = mat_to_elems_.at(c.material_index_);
+      for (int i = 0; i < openmc_driver_->cells_.size(); ++i) {
+        if (cell_fluid_mask_[i] == 1) {
+          auto& c = openmc_driver_->cells_[i];
+          const auto& global_elems = mat_to_elems_.at(c.material_index_);
 
-        for (int elem: global_elems) {
-          double rho = c.get_density();
-          densities_[elem] = rho;
-          densities_prev_[elem] = rho;
+          for (int elem: global_elems) {
+            double rho = c.get_density();
+            densities_[elem] = rho;
+            densities_prev_[elem] = rho;
+          }
         }
       }
     }


### PR DESCRIPTION
This MR defines the `densities_` and `densities_prev_` members in `CoupledDriver` in a similar manner to how we define temperatures and the heat source.

This MR updates `OpenmcNekDriver` to set the initial densities either from the OpenMC input or from the Nek restart file (by calling IAPWS on a restart temperature with pressure BC). This will permit accurate estimates of convergence based on density between the first and second iterations if we decide to use that.

This is marked as WIP until !1254 is merged into OpenMC and we do a submodule update here.