### PR TITLE
Temperature relaxation

### DIFF
--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -42,7 +42,10 @@ public:
   virtual void set_heat_source() {}
 
   //! Update the temperature for the neutronics solver
-  virtual void update_temperature() {}
+  virtual void update_temperature() final;
+
+  //! Set the temperature in the neutronics solver
+  virtual void set_temperature() {};
 
   //! Update the density for the neutronics solver
   virtual void update_density() {}
@@ -91,8 +94,13 @@ public:
   //! Picard iteration convergence tolerance, defaults to 1e-3 if not set
   double epsilon_{1e-3};
 
-  //! Constant relaxation factor, defaults to 1.0 (standard Picard) if not set
+  //! Constant relaxation factor for the heat source,
+  //! defaults to 1.0 (standard Picard) if not set
   double alpha_{1.0};
+
+  //! Constant relaxation factor for the temperature, defaults to the
+  //! relaxation aplied to the heat source if not set
+  double alpha_T_{alpha_};
 
   //! Enumeration of available temperature initial condition specifications.
   //! 'neutronics' sets temperature condition from the neutronics input files,

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -36,13 +36,13 @@ public:
   virtual bool has_global_coupling_data() const = 0;
 
   //! Update the heat source for the thermal-hydraulics solver
-  virtual void update_heat_source() final;
+  void update_heat_source();
 
   //! Set the heat source in the thermal-hydraulics solver
   virtual void set_heat_source() {}
 
   //! Update the temperature for the neutronics solver
-  virtual void update_temperature() final;
+  void update_temperature();
 
   //! Set the temperature in the neutronics solver
   virtual void set_temperature() {};

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -15,6 +15,11 @@ public:
 
   virtual ~HeatFluidsDriver() = default;
 
+  //! Whether the calling rank has access to the fields returned
+  //! by the 'temperature', 'density', and 'fluid_mask' methods
+  //! \return Whether calling rank has access
+  virtual bool has_coupling_data() const = 0;
+
   //! Get the temperature in each region
   //! \return Temperature in each region as [K]
   virtual xt::xtensor<double, 1> temperature() const = 0;

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -44,6 +44,10 @@ public:
   //! initialization and finalization for each step.
   void solve_step() final;
 
+  //! Whether the calling rank has access to the full thermal-hydraulic solution field.
+  //! Only Nek's master rank has access to the global data; data on other ranks is empty
+  bool has_coupling_data() const final { return comm_.rank == 0; }
+
   xt::xtensor<double, 1> temperature() const final;
 
   xt::xtensor<double, 1> density() const final;

--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -32,7 +32,7 @@ public:
 
   void set_heat_source() override;
 
-  void update_temperature() override;
+  void set_temperature() override;
 
   NeutronicsDriver& get_neutronics_driver() const override;
 

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -40,7 +40,7 @@ public:
 
   void set_heat_source() override;
 
-  void update_temperature() override;
+  void set_temperature() override;
 
   void update_density() override;
 

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -21,6 +21,8 @@ public:
   //! \param node  XML node containing settings for surrogate
   explicit SurrogateHeatDriver(MPI_Comm comm, double pressure_bc, pugi::xml_node node);
 
+  bool has_coupling_data() const final { return true; }
+
   //! Solves the heat-fluids surrogate solver
   void solve_step() final;
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -22,6 +22,9 @@ CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
   if (node.child("alpha"))
     alpha_ = node.child("alpha").text().as_double();
 
+  if (node.child("alpha_T"))
+    alpha_T_ = node.child("alpha_T").text().as_double();
+
   if (node.child("temperature_ic")) {
     auto s = std::string{node.child_value("temperature_ic")};
 
@@ -168,6 +171,27 @@ void CoupledDriver::update_heat_source()
 
   // Set heat source in the thermal-hydraulics solver
   set_heat_source();
+}
+
+void CoupledDriver::update_temperature()
+{
+  // Store previous temperature solution; a previous solution will always be present
+  // because a temperature IC is set and the neutronics solver runs first
+  if (has_global_coupling_data()) {
+    std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
+  }
+
+  // Compute the next iterate of the temperature
+  auto& heat = get_heat_driver();
+  if (heat.active()) {
+    auto t = heat.temperature();
+
+    if (heat.has_coupling_data())
+      temperatures_ = alpha_T_ * t + (1.0 - alpha_T_) * temperatures_prev_;
+  }
+
+  // Set temperature in the neutronics solver
+  set_temperature();
 }
 
 } // namespace enrico

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -208,14 +208,10 @@ void OpenmcHeatDriver::set_heat_source()
   }
 }
 
-void OpenmcHeatDriver::update_temperature()
+void OpenmcHeatDriver::set_temperature()
 {
-  std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
-
   const auto& r_fuel = heat_driver_->r_grid_fuel_;
   const auto& r_clad = heat_driver_->r_grid_clad_;
-
-  temperatures_ = heat_driver_->temperature();
 
   // For each OpenMC material, volume average temperatures and set
   for (int i = 0; i < openmc_driver_->cells_.size(); ++i) {

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -305,7 +305,7 @@ void OpenmcNekDriver::init_elem_fluid_mask()
     // On Nek's master rank, fm gets global data. On Nek's other ranks, fm is empty
     auto fm = nek_driver_->fluid_mask();
     // Initialize elem_fluid_mask_ on Nek's master rank only
-    if (nek_driver_->comm_.rank == 0) {
+    if (nek_driver_->has_coupling_data()) {
       elem_fluid_mask_ = fm;
     }
     // Since OpenMC's and Nek's master ranks are the same, we know that elem_fluid_mask_
@@ -418,7 +418,9 @@ void OpenmcNekDriver::update_density()
   if (nek_driver_->active()) {
     // On Nek's master rank, d gets global data. On Nek's other ranks, d is empty.
     auto d = nek_driver_->density();
-    if (nek_driver_->comm_.rank == 0) {
+
+    // Update elem_densities_ on Nek's master rank only.
+    if (nek_driver_->has_coupling_data()) {
       densities_ = d;
     }
 

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -368,18 +368,9 @@ void OpenmcNekDriver::set_heat_source()
   }
 }
 
-void OpenmcNekDriver::update_temperature()
+void OpenmcNekDriver::set_temperature()
 {
-  if (this->has_global_coupling_data()) {
-    std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
-  }
-
   if (nek_driver_->active()) {
-    auto t = nek_driver_->temperature();
-    if (nek_driver_->comm_.rank == 0) {
-      temperatures_ = t;
-    }
-
     if (openmc_driver_->active()) {
       // Broadcast global_element_temperatures onto all the OpenMC procs
       openmc_driver_->comm_.Bcast(temperatures_.data(), n_global_elem_, MPI_DOUBLE);


### PR DESCRIPTION
This MR adds temperature underrelaxation to the `CoupledDriver`, which moves the saving and setting of `temperatures_` and `temperatures_prev_` to the `CoupledDriver` such that its derived classes only need to define `set_temperature()` based on mappings between the two physics tools.