### PR TITLE
Add Multi_Pin_Subchannel member variables

### DIFF
--- a/include/smrt/Multi_Pin_Subchannel.h
+++ b/include/smrt/Multi_Pin_Subchannel.h
@@ -33,9 +33,9 @@ public:
   using SP_Pin_Subchannel = std::shared_ptr<Single_Pin_Subchannel>;
   //@}
 
-  virtual std::vector<double> temperature() const { return pin_temps; }
+  virtual std::vector<double> temperature() const { return d_pin_temps; }
 
-  virtual std::vector<double> density() const { return pin_densities; }
+  virtual std::vector<double> density() const { return d_pin_densities; }
 
 private:
   // >>> DATA
@@ -55,11 +55,11 @@ private:
 
   //! coolant temperature in [K] for each channel, of total length given by the
   //! product of the number of pins by the number of axial cells
-  std::vector<double> pin_temps;
+  std::vector<double> d_pin_temps;
 
   //! coolant density in [g/cm^3] for each channel, of total length given by the
   //! product of the number of pins by the number of axial cells
-  std::vector<double> pin_densities;
+  std::vector<double> d_pin_densities;
 
 public:
   // Constructor
@@ -71,7 +71,7 @@ public:
   void solve(const std::vector<double>& power);
 
   //! heat source
-  std::vector<double> pin_powers;
+  std::vector<double> d_pin_powers;
 
 private:
   //! Set up the sizes of solution arrays

--- a/include/smrt/Multi_Pin_Subchannel.h
+++ b/include/smrt/Multi_Pin_Subchannel.h
@@ -33,6 +33,8 @@ public:
   using SP_Pin_Subchannel = std::shared_ptr<Single_Pin_Subchannel>;
   //@}
 
+  virtual std::vector<double> temperature() const { return pin_temps; }
+
 private:
   // >>> DATA
   SP_Assembly d_assembly;
@@ -49,6 +51,10 @@ private:
 
   SP_Pin_Subchannel d_pin_subchannel;
 
+  //! coolant temperature in [K] for each channel, of total length given by the
+  //! product of the number of pins by the number of axial cells
+  std::vector<double> pin_temps;
+
 public:
   // Constructor
   Multi_Pin_Subchannel(SP_Assembly assembly,
@@ -57,10 +63,12 @@ public:
 
   // Solve
   void solve(const std::vector<double>& power,
-             std::vector<double>& channel_temp,
              std::vector<double>& channel_density);
 
 private:
+  //! Set up the sizes of solution arrays
+  void generate_arrays();
+
   int channel_index(int ix, int iy) const
   {
     Expects(ix < d_Nx);

--- a/include/smrt/Multi_Pin_Subchannel.h
+++ b/include/smrt/Multi_Pin_Subchannel.h
@@ -35,6 +35,8 @@ public:
 
   virtual std::vector<double> temperature() const { return pin_temps; }
 
+  virtual std::vector<double> density() const { return pin_densities; }
+
 private:
   // >>> DATA
   SP_Assembly d_assembly;
@@ -55,6 +57,10 @@ private:
   //! product of the number of pins by the number of axial cells
   std::vector<double> pin_temps;
 
+  //! coolant density in [g/cm^3] for each channel, of total length given by the
+  //! product of the number of pins by the number of axial cells
+  std::vector<double> pin_densities;
+
 public:
   // Constructor
   Multi_Pin_Subchannel(SP_Assembly assembly,
@@ -62,8 +68,7 @@ public:
                        const std::vector<double>& dz);
 
   // Solve
-  void solve(const std::vector<double>& power,
-             std::vector<double>& channel_density);
+  void solve(const std::vector<double>& power);
 
 private:
   //! Set up the sizes of solution arrays

--- a/include/smrt/Multi_Pin_Subchannel.h
+++ b/include/smrt/Multi_Pin_Subchannel.h
@@ -70,6 +70,9 @@ public:
   // Solve
   void solve(const std::vector<double>& power);
 
+  //! heat source
+  std::vector<double> pin_powers;
+
 private:
   //! Set up the sizes of solution arrays
   void generate_arrays();

--- a/src/smrt/Multi_Pin_Subchannel.cpp
+++ b/src/smrt/Multi_Pin_Subchannel.cpp
@@ -65,18 +65,17 @@ void Multi_Pin_Subchannel::generate_arrays()
   int pins_y = d_assembly->num_pins_y();
 
   pin_temps = xt::empty<double>({pins_x * pins_y * d_Nz});
+  pin_densities = xt::empty<double>({pins_x * pins_y * d_Nz});
 }
 
 //---------------------------------------------------------------------------//
 // Solve subchannel equations over all pins
 //---------------------------------------------------------------------------//
-void Multi_Pin_Subchannel::solve(const std::vector<double>& pin_powers,
-                                 std::vector<double>& pin_densities)
+void Multi_Pin_Subchannel::solve(const std::vector<double>& pin_powers)
 {
   int pins_x = d_assembly->num_pins_x();
   int pins_y = d_assembly->num_pins_y();
   Expects(pin_powers.size() == pins_x * pins_y * d_Nz);
-  Expects(pin_densities.size() == pins_x * pins_y * d_Nz);
 
   // Convenience function to compute pin index
   auto pin_index = [pins_x, pins_y](int ix, int iy, int iz) {

--- a/src/smrt/Multi_Pin_Subchannel.cpp
+++ b/src/smrt/Multi_Pin_Subchannel.cpp
@@ -54,19 +54,28 @@ Multi_Pin_Subchannel::Multi_Pin_Subchannel(SP_Assembly assembly,
   d_pin_subchannel = std::make_shared<Single_Pin_Subchannel>(parameters, dz);
   d_pin_subchannel->set_inlet_temperature(inlet_temp);
   d_pin_subchannel->set_exit_pressure(exit_press);
+
+  // set up solution arrays
+  generate_arrays();
+}
+
+void Multi_Pin_Subchannel::generate_arrays()
+{
+  int pins_x = d_assembly->num_pins_x();
+  int pins_y = d_assembly->num_pins_y();
+
+  pin_temps = xt::empty<double>({pins_x * pins_y * d_Nz});
 }
 
 //---------------------------------------------------------------------------//
 // Solve subchannel equations over all pins
 //---------------------------------------------------------------------------//
 void Multi_Pin_Subchannel::solve(const std::vector<double>& pin_powers,
-                                 std::vector<double>& pin_temps,
                                  std::vector<double>& pin_densities)
 {
   int pins_x = d_assembly->num_pins_x();
   int pins_y = d_assembly->num_pins_y();
   Expects(pin_powers.size() == pins_x * pins_y * d_Nz);
-  Expects(pin_temps.size() == pins_x * pins_y * d_Nz);
   Expects(pin_densities.size() == pins_x * pins_y * d_Nz);
 
   // Convenience function to compute pin index

--- a/src/smrt/Multi_Pin_Subchannel.cpp
+++ b/src/smrt/Multi_Pin_Subchannel.cpp
@@ -64,9 +64,9 @@ void Multi_Pin_Subchannel::generate_arrays()
   int pins_x = d_assembly->num_pins_x();
   int pins_y = d_assembly->num_pins_y();
 
-  pin_temps.resize(pins_x * pins_y * d_Nz);
-  pin_densities.resize(pins_x * pins_y * d_Nz);
-  pin_powers.resize(pins_x * pins_y * d_Nz);
+  d_pin_temps.resize(pins_x * pins_y * d_Nz);
+  d_pin_densities.resize(pins_x * pins_y * d_Nz);
+  d_pin_powers.resize(pins_x * pins_y * d_Nz);
 }
 
 //---------------------------------------------------------------------------//
@@ -74,7 +74,7 @@ void Multi_Pin_Subchannel::generate_arrays()
 //---------------------------------------------------------------------------//
 void Multi_Pin_Subchannel::solve(const std::vector<double>& powers)
 {
-  pin_powers = powers;
+  d_pin_powers = powers;
 
   // Convenience function to compute pin index
   auto pin_index = [pins_x, pins_y](int ix, int iy, int iz) {
@@ -86,8 +86,8 @@ void Multi_Pin_Subchannel::solve(const std::vector<double>& powers)
   };
 
   // Solve in each channel
-  std::fill(pin_temps.begin(), pin_temps.end(), 0.0);
-  std::fill(pin_densities.begin(), pin_densities.end(), 0.0);
+  std::fill(d_pin_temps.begin(), d_pin_temps.end(), 0.0);
+  std::fill(d_pin_densities.begin(), d_pin_densities.end(), 0.0);
   std::vector<double> channel_power(d_Nz);
   std::vector<double> channel_temp(d_Nz);
   std::vector<double> channel_density(d_Nz);
@@ -99,19 +99,19 @@ void Multi_Pin_Subchannel::solve(const std::vector<double>& powers)
 
         // Upper right
         if (ix < pins_x && iy < pins_y)
-          channel_power[iz] += pin_powers[pin_index(ix, iy, iz)];
+          channel_power[iz] += d_pin_powers[pin_index(ix, iy, iz)];
 
         // Upper left
         if (ix > 0 && iy < pins_y)
-          channel_power[iz] += pin_powers[pin_index(ix - 1, iy, iz)];
+          channel_power[iz] += d_pin_powers[pin_index(ix - 1, iy, iz)];
 
         // Lower right
         if (ix < pins_x && iy > 0)
-          channel_power[iz] += pin_powers[pin_index(ix, iy - 1, iz)];
+          channel_power[iz] += d_pin_powers[pin_index(ix, iy - 1, iz)];
 
         // Lower left
         if (ix > 0 && iy > 0)
-          channel_power[iz] += pin_powers[pin_index(ix - 1, iy - 1, iz)];
+          channel_power[iz] += d_pin_powers[pin_index(ix - 1, iy - 1, iz)];
 
         channel_power[iz] *= 0.25;
       }
@@ -127,29 +127,29 @@ void Multi_Pin_Subchannel::solve(const std::vector<double>& powers)
         // Upper right
         if (ix < pins_x && iy < pins_y) {
           int idx = pin_index(ix, iy, iz);
-          pin_temps[idx] += 0.25 * channel_temp[iz];
-          pin_densities[idx] += 0.25 * channel_density[iz];
+          d_pin_temps[idx] += 0.25 * channel_temp[iz];
+          d_pin_densities[idx] += 0.25 * channel_density[iz];
         }
 
         // Upper left
         if (ix > 0 && iy < pins_y) {
           int idx = pin_index(ix - 1, iy, iz);
-          pin_temps[idx] += 0.25 * channel_temp[iz];
-          pin_densities[idx] += 0.25 * channel_density[iz];
+          d_pin_temps[idx] += 0.25 * channel_temp[iz];
+          d_pin_densities[idx] += 0.25 * channel_density[iz];
         }
 
         // Lower right
         if (ix < pins_x && iy > 0) {
           int idx = pin_index(ix, iy - 1, iz);
-          pin_temps[idx] += 0.25 * channel_temp[iz];
-          pin_densities[idx] += 0.25 * channel_density[iz];
+          d_pin_temps[idx] += 0.25 * channel_temp[iz];
+          d_pin_densities[idx] += 0.25 * channel_density[iz];
         }
 
         // Lower left
         if (ix > 0 && iy > 0) {
           int idx = pin_index(ix - 1, iy - 1, iz);
-          pin_temps[idx] += 0.25 * channel_temp[iz];
-          pin_densities[idx] += 0.25 * channel_density[iz];
+          d_pin_temps[idx] += 0.25 * channel_temp[iz];
+          d_pin_densities[idx] += 0.25 * channel_density[iz];
         }
       }
     }

--- a/src/smrt/Multi_Pin_Subchannel.cpp
+++ b/src/smrt/Multi_Pin_Subchannel.cpp
@@ -64,18 +64,17 @@ void Multi_Pin_Subchannel::generate_arrays()
   int pins_x = d_assembly->num_pins_x();
   int pins_y = d_assembly->num_pins_y();
 
-  pin_temps = xt::empty<double>({pins_x * pins_y * d_Nz});
-  pin_densities = xt::empty<double>({pins_x * pins_y * d_Nz});
+  pin_temps.resize(pins_x * pins_y * d_Nz);
+  pin_densities.resize(pins_x * pins_y * d_Nz);
+  pin_powers.resize(pins_x * pins_y * d_Nz);
 }
 
 //---------------------------------------------------------------------------//
 // Solve subchannel equations over all pins
 //---------------------------------------------------------------------------//
-void Multi_Pin_Subchannel::solve(const std::vector<double>& pin_powers)
+void Multi_Pin_Subchannel::solve(const std::vector<double>& powers)
 {
-  int pins_x = d_assembly->num_pins_x();
-  int pins_y = d_assembly->num_pins_y();
-  Expects(pin_powers.size() == pins_x * pins_y * d_Nz);
+  pin_powers = powers;
 
   // Convenience function to compute pin index
   auto pin_index = [pins_x, pins_y](int ix, int iy, int iz) {

--- a/src/smrt/Multiphysics_Driver.cpp
+++ b/src/smrt/Multiphysics_Driver.cpp
@@ -112,8 +112,9 @@ void Multiphysics_Driver::solve()
   for (int it = 0; it < d_max_iters; ++it) {
     old_power = d_power;
 
-    d_subchannel->solve(d_power, d_coolant_density);
+    d_subchannel->solve(d_power);
     d_coolant_temperature = d_subchannel->temperature();
+    d_coolant_density = d_subchannel->density();
 
     d_conduction->solve(d_power, d_coolant_temperature, d_fuel_temperature);
     d_neutronics->solve(d_fuel_temperature, d_coolant_density, d_power);

--- a/src/smrt/Multiphysics_Driver.cpp
+++ b/src/smrt/Multiphysics_Driver.cpp
@@ -112,7 +112,9 @@ void Multiphysics_Driver::solve()
   for (int it = 0; it < d_max_iters; ++it) {
     old_power = d_power;
 
-    d_subchannel->solve(d_power, d_coolant_temperature, d_coolant_density);
+    d_subchannel->solve(d_power, d_coolant_density);
+    d_coolant_temperature = d_subchannel->temperature();
+
     d_conduction->solve(d_power, d_coolant_temperature, d_fuel_temperature);
     d_neutronics->solve(d_fuel_temperature, d_coolant_density, d_power);
 


### PR DESCRIPTION
To increase similarity to the `HeatFluidsDriver` base class, this MR adds private temperature and density members to the `Multi_Pin_Subchannel` solver that are explicitly retrieved from the `Multiphysics_Driver` class.

A private `pin_powers` member is also added that in the future will be explicitly updated by a coupled driver instead of within the `solve` method [but I didn't do that here to keep things small to try to get successful compilation :) ].