### PR TITLE
Fixes for heat surrogate with multiple pins

### DIFF
--- a/doc/source/input.rst
+++ b/doc/source/input.rst
@@ -60,6 +60,21 @@ Choosing :math:`\alpha = 1` corresponds to no underrelaxation.
 
 *Default*: 1.0
 
+``<alpha_T>``
+-------------
+
+Underrelaxation parameter used on a temperature update. Let :math:`T_i` be the
+temperature at iteration :math:`i` and :math:`\tilde{T}_{i+1}` be next estimate
+of the temperature as determined by the neutronics solver. Then, the temperature
+for iteration :math:`i + 1` is:
+
+.. math::
+    T_{i+1} = (1 - \alpha_T) T_i + \alpha_T \tilde{T}_{i+1}
+
+Choosing :math:`\alpha_T = 1` corresponds to no underrelaxation.
+
+*Default*: The same value chosen for ``<alpha>``
+
 ``<temperature_ic>``
 --------------------
 
@@ -72,7 +87,7 @@ heat-fluids solver.
 *Default*: neutronics
 
 ``<density_ic>``
---------------------
+----------------
 
 The initial density distribution can be determined either from the
 neutronics solver or the heat-fluids solver. A value of "neutronics" will use
@@ -85,7 +100,7 @@ and is unchanged from the value used in the neutronics input.
 *Default*: neutronics
 
 ``<pressure_bc>``
---------------
+-----------------
 
 The pressure of the outlet boundary condition in units of [MPa].
 

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -66,7 +66,8 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
   return heat;
 }
 
-void OpenmcDriver::normalize_heat_source(xt::xtensor<double, 1>& heat_source, double power) const
+void OpenmcDriver::normalize_heat_source(xt::xtensor<double, 1>& heat_source,
+                                         double power) const
 {
   // Get total heat production [J/source]
   double total_heat = xt::sum(heat_source)();
@@ -94,7 +95,7 @@ void OpenmcDriver::solve_step()
 
 void OpenmcDriver::write_step(int timestep, int iteration)
 {
-  std::string filename{"openmc_" + std::to_string(timestep) + "_" +
+  std::string filename{"openmc_t" + std::to_string(timestep) + "_i" +
                        std::to_string(iteration) + ".h5"};
   err_chk(openmc_statepoint_write(filename.c_str(), nullptr));
 }

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -57,6 +57,10 @@ void OpenmcHeatDriver::init_mappings()
   int n_azimuthal = 4;
 
   for (int i = 0; i < heat_driver_->n_pins_; ++i) {
+    // Get coordinate of pin center
+    double x_center = heat_driver_->pin_centers_(i, 0);
+    double y_center = heat_driver_->pin_centers_(i, 1);
+
     for (int j = 0; j < heat_driver_->n_axial_; ++j) {
       // Get average z value
       double zavg = 0.5 * (z(j) + z(j + 1));
@@ -74,8 +78,8 @@ void OpenmcHeatDriver::init_mappings()
         for (int m = 0; m < n_azimuthal; ++m) {
           double m_avg = m + 0.5;
           double theta = 2.0 * m_avg * PI / n_azimuthal;
-          double x = ravg * std::cos(theta);
-          double y = ravg * std::sin(theta);
+          double x = x_center + ravg * std::cos(theta);
+          double y = y_center + ravg * std::sin(theta);
 
           // Determine cell instance corresponding to given pin location
           Position r{x, y, zavg};
@@ -123,18 +127,19 @@ void OpenmcHeatDriver::init_temperatures()
 
     if (temperature_ic_ == Initial::neutronics) {
       // Loop over all of the rings in the heat transfer model and set the temperature IC
-      // based on temperatures used in the OpenMC input file. More than one OpenMC cell may
-      // correspond to a particular ring, so the initial temperature set for that ring should
-      // be a volume average of the OpenMC cell temperatures.
+      // based on temperatures used in the OpenMC input file. More than one OpenMC cell
+      // may correspond to a particular ring, so the initial temperature set for that ring
+      // should be a volume average of the OpenMC cell temperatures.
 
       // TODO: This initial condition used in the coupled driver does not truly represent
-      // the actual initial condition used in the OpenMC input file, since the surrogate heat
-      // solver only includes a radial dependence, though the various azimuthal segments
-      // corresponding to a single heat transfer ring may run with different initial
-      // temperatures. For this reading of the initial condition to be completely accurate,
-      // the heat solver must either be modified to include an azimuthal dependence, or
-      // a check inserted here to ensure that the initial temperatures in the azimuthal
-      // segments in the OpenMC model are all the same (i.e. no initial azimuthal dependence).
+      // the actual initial condition used in the OpenMC input file, since the surrogate
+      // heat solver only includes a radial dependence, though the various azimuthal
+      // segments corresponding to a single heat transfer ring may run with different
+      // initial temperatures. For this reading of the initial condition to be completely
+      // accurate, the heat solver must either be modified to include an azimuthal
+      // dependence, or a check inserted here to ensure that the initial temperatures in
+      // the azimuthal segments in the OpenMC model are all the same (i.e. no initial
+      // azimuthal dependence).
 
       int ring_index = 0;
       for (int i = 0; i < heat_driver_->n_pins_; ++i) {
@@ -166,8 +171,9 @@ void OpenmcHeatDriver::init_temperatures()
     }
 
     if (temperature_ic_ == Initial::heat) {
-      throw std::runtime_error{"Temperature initial conditions from surrogate heat-fluids "
-                               "solver not supported."};
+      throw std::runtime_error{
+        "Temperature initial conditions from surrogate heat-fluids "
+        "solver not supported."};
     }
   }
 }

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -159,7 +159,7 @@ void SurrogateHeatDriver::write_step(int timestep, int iteration)
   std::stringstream filename;
   filename << viz_basename_;
   if (iteration >= 0 && timestep >= 0) {
-    filename << "_" << timestep << "_" << iteration;
+    filename << "_t" << timestep << "_i" << iteration;
   }
   filename << ".vtk";
 

--- a/src/vtk_viz.cpp
+++ b/src/vtk_viz.cpp
@@ -312,8 +312,8 @@ xtensor<double, 1> SurrogateVtkWriter::points_for_pin(double x, double y)
   xtensor<double, 1> points_out = points_;
 
   // translate points to pin center
-  xt::view(points_out, xt::range(0, _, 3)) += y;
-  xt::view(points_out, xt::range(1, _, 3)) += x;
+  xt::view(points_out, xt::range(0, _, 3)) += x;
+  xt::view(points_out, xt::range(1, _, 3)) += y;
 
   return points_out;
 }
@@ -404,10 +404,6 @@ xtensor<double, 3> SurrogateVtkWriter::clad_points()
     xt::view(pnts_out, i, xt::all(), 1) = y;
     xt::view(pnts_out, i, xt::all(), 2) = surrogate_.z_[i];
   }
-
-  // translate to pin center
-  xt::view(pnts_out, 0) += surrogate_.pin_centers_(0, 0);
-  xt::view(pnts_out, 1) += surrogate_.pin_centers_(0, 1);
 
   return pnts_out;
 }


### PR DESCRIPTION
The primary purpose of this PR is to fix a few bugs when running the heat surrogate model with multiple pins. I also changed the filename format for OpenMC statepoints to `openmc_t#_i#.h5` to indicate "timestep" and "iteration" (same thing for viz files).

@pshriwise can you take a look at my fixes in vtk_viz.cpp to see if they make sense to you?