### PR TITLE
Fix some compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.3)
 project(enrico Fortran C CXX)
 
+# On BG/Q, linking requires -dynamic, not -rdynamic
+if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ppc64")
+  set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "-dynamic")
+endif ()
+
 # =============================================================================
 # Check for SCALE (optional)
 # =============================================================================

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -84,8 +84,8 @@ void OpenmcNekDriver::init_mpi_datatypes()
 void OpenmcNekDriver::init_mappings()
 {
   if (this->has_global_coupling_data()) {
-    elem_centroids_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
-    elem_fluid_mask_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
+    elem_centroids_.resize(n_global_elem_);
+    elem_fluid_mask_.resize({n_global_elem_});
   }
 
   if (nek_driver_->active()) {
@@ -269,20 +269,19 @@ void OpenmcNekDriver::init_densities()
         const auto& global_elems = mat_to_elems_.at(c.material_index_);
 
         if (cell_fluid_mask_[i] == 1) {
-          for (int elem: global_elems) {
+          for (int elem : global_elems) {
             double rho = c.get_density();
             densities_[elem] = rho;
             densities_prev_[elem] = rho;
           }
         } else {
-            for (int elem: global_elems) {
-              densities_[elem] = 0.0;
-              densities_prev_[elem] = 0.0;
-            }
+          for (int elem : global_elems) {
+            densities_[elem] = 0.0;
+            densities_prev_[elem] = 0.0;
+          }
         }
       }
-    }
-    else if (density_ic_ == Initial::heat) {
+    } else if (density_ic_ == Initial::heat) {
       // Use whatever density is in Nek's internal arrays, either from a restart
       // file or from a useric fortran routine
       update_density();

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -150,8 +150,8 @@ void SurrogateHeatDriver::write_step(int timestep, int iteration)
 {
   // if called, but viz isn't requested for the situation,
   // exit early - no output
-  if (iteration < 0 && "final" != viz_iterations_ ||
-      iteration >= 0 && "all" != viz_iterations_) {
+  if ((iteration < 0 && "final" != viz_iterations_) ||
+      (iteration >= 0 && "all" != viz_iterations_)) {
     return;
   }
 


### PR DESCRIPTION
This PR:

- Fixes some compile warnings that clang gives
- Ensures that ENRICO is built with `-dynamic` on BG/Q instead of `-rdynamic`