### PR TITLE
Use cell instances for Nek <-> OpenMC mappings

### DIFF
--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -31,7 +31,8 @@ public:
 
   xt::xtensor<double, 1> heat_source(double power) const final;
 
-  void normalize_heat_source(xt::xtensor<double, 1>& heat_source, double power) const final;
+  void normalize_heat_source(xt::xtensor<double, 1>& heat_source,
+                             double power) const final;
 
   //! Initialization required in each Picard iteration
   void init_step() final;
@@ -46,14 +47,6 @@ public:
 
   //! Finalization required in each Picard iteration
   void finalize_step() final;
-
-  //! Get the coordinate of a given material's centroid
-  //!
-  //! This coordinate has the units used by OpenMC (cm)
-  //!
-  //! \param mat_id A material ID
-  //! \return The coordinate of the material's centroid in cm
-  Position get_mat_centroid(int32_t mat_id) const;
 
   // Data
   openmc::Tally* tally_;            //!< Fission energy deposition tally

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -4,9 +4,9 @@
 #define ENRICO_OPENMC_NEK_DRIVER_H
 
 #include "enrico/coupled_driver.h"
+#include "enrico/message_passing.h"
 #include "enrico/nek_driver.h"
 #include "enrico/openmc_driver.h"
-#include "enrico/message_passing.h"
 #include "mpi.h"
 
 #include <unordered_set>
@@ -46,24 +46,24 @@ public:
 
   NeutronicsDriver& get_neutronics_driver() const override;
 
-  HeatFluidsDriver & get_heat_driver() const override;
+  HeatFluidsDriver& get_heat_driver() const override;
 
-  Comm intranode_comm_; //!< The communicator representing intranode ranks
+  Comm intranode_comm_;       //!< The communicator representing intranode ranks
   int openmc_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in OpenMC
                               //!< comm
 
 protected:
   //! Initialize global temperature buffers on all OpenMC ranks.
   //!
-  //! These arrays store the dimensionless temperatures of Nek's global elements. These are **not**
-  //! ordered by Nek's global element indices. Rather, these are ordered according
-  //! to an MPI_Gatherv operation on Nek5000's local elements.
+  //! These arrays store the dimensionless temperatures of Nek's global elements. These
+  //! are **not** ordered by Nek's global element indices. Rather, these are ordered
+  //! according to an MPI_Gatherv operation on Nek5000's local elements.
   void init_temperatures() override;
 
   //! Initialize global source buffers on all OpenMC ranks.
   //!
-  //! These arrays store the dimensionless source of Nek's global elements. These are **not**
-  //! ordered by Nek's global element indices. Rather, these are ordered according
+  //! These arrays store the dimensionless source of Nek's global elements. These are
+  //! **not** ordered by Nek's global element indices. Rather, these are ordered according
   //! to an MPI_Gatherv operation on Nek5000's local elements.
   void init_heat_source() override;
 
@@ -76,8 +76,8 @@ protected:
 
   //! Initialize global fluid masks on all OpenMC ranks.
   //!
-  //! These arrays store the dimensionless source of Nek's global elements. These are **not**
-  //! ordered by Nek's global element indices. Rather, these are ordered according
+  //! These arrays store the dimensionless source of Nek's global elements. These are
+  //! **not** ordered by Nek's global element indices. Rather, these are ordered according
   //! to an MPI_Gatherv operation on Nek5000's local elements.
   void init_elem_fluid_mask();
 
@@ -88,7 +88,7 @@ private:
   //! Initialize MPI datatypes (currently, only position_mpi_datatype)
   void init_mpi_datatypes();
 
-  //! Create bidirectional mappings from OpenMC materials to/from Nek5000 elements
+  //! Create bidirectional mappings from OpenMC cell instances to/from Nek5000 elements
   void init_mappings();
 
   //! Initialize the tallies for all OpenMC materials
@@ -102,7 +102,7 @@ private:
 
   std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
 
-  std::unique_ptr<NekDriver> nek_driver_;       //!< The Nek5000 driver
+  std::unique_ptr<NekDriver> nek_driver_; //!< The Nek5000 driver
 
   //! MPI datatype for sending/receiving Position objects.
   MPI_Datatype position_mpi_datatype;
@@ -125,22 +125,20 @@ private:
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
   xt::xtensor<double, 1> elem_volumes_;
 
-  //! Map that gives a list of Nek element global indices for a given OpenMC material
-  //! index. The Nek global element indices refer to indices defined by the MPI_Gatherv
-  //! operation, and do not reflect Nek's internal global element indexing.
-  std::unordered_map<int32_t, std::vector<int>> mat_to_elems_;
+  //! Map that gives a list of Nek element global indices for a given OpenMC
+  //! cell instance index. The Nek global element indices refer to indices
+  //! defined by the MPI_Gatherv operation, and do not reflect Nek's internal
+  //! global element indexing.
+  std::unordered_map<int32_t, std::vector<int>> cell_to_elems_;
 
-  //! Map that gives the OpenMC material index for a given Nek global element index.
-  //! The Nek global element indices refer to indices defined by the MPI_Gatherv
-  //! operation, and do not reflect Nek's internal global element indexing.
-  std::unordered_map<int, int32_t> elem_to_mat_;
+  //! Map that gives the OpenMC cell instance indices for a given Nek global
+  //! element index. The Nek global element indices refer to indices defined by
+  //! the MPI_Gatherv operation, and do not reflect Nek's internal global
+  //! element indexing.
+  std::unordered_map<int, int32_t> elem_to_cell_;
 
-  //! Mapping of material indices (minus 1) to positions in array of heat sources that is
-  //! used during update_heat_source
-  std::vector<int> heat_index_;
-
-  //! Number of materials in OpenMC model
-  int32_t n_materials_;
+  //! Number of cell instances in OpenMC model
+  int32_t n_cells_;
 
   //! Number of Nek local elements on this MPI rank.
   //! If nek_driver_ is active, this equals nek_driver.nelt_.  If not, it equals 0.

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -119,11 +119,11 @@ void OpenmcNekDriver::init_mappings()
       openmc_driver_->comm_.Bcast(elem_fluid_mask_.data(), n_global_elem_, MPI_INT);
     }
 
-    // Step 2: Set element->material and material->element mappings
-    // Create buffer to store material IDs corresponding to each Nek global
+    // Step 2: Set element->cell and cell->element mappings
+    // Create buffer to store cell instance indices corresponding to each Nek global
     // element. This is needed because calls to OpenMC API functions can only be
     // made from processes
-    int32_t mat_idx[n_global_elem_];
+    int32_t cell_idx[n_global_elem_];
 
     if (openmc_driver_->active()) {
       std::unordered_set<int32_t> tracked;
@@ -136,45 +136,27 @@ void OpenmcNekDriver::init_mappings()
           openmc_driver_->cells_.push_back(c);
           tracked.insert(c.material_index_);
         }
-        // Get corresponding material
-        mat_to_elems_[c.material_index_].push_back(i);
-        // Set value for material ID in array
-        mat_idx[i] = c.material_index_;
+        // Get corresponding cell instance
+        auto i_cell = openmc_driver_->cells_.size() - 1;
+        cell_to_elems_[i_cell].push_back(i);
+        // Set value for cell instance in array
+        cell_idx[i] = i_cell;
       }
 
-      // Determine number of unique OpenMC materials
-      n_materials_ = openmc_driver_->cells_.size();
+      // Determine number of OpenMC cell instances
+      n_cells_ = openmc_driver_->cells_.size();
     }
 
-    // Broadcast array of material IDs to each Nek rank
-    intranode_comm_.Bcast(mat_idx, n_global_elem_, MPI_INT32_T);
+    // Broadcast array of cell instance indices to each Nek rank
+    intranode_comm_.Bcast(cell_idx, n_global_elem_, MPI_INT32_T);
 
-    // Broadcast number of materials
-    intranode_comm_.Bcast(&n_materials_, 1, MPI_INT32_T);
+    // Broadcast number of cell instances
+    intranode_comm_.Bcast(&n_cells_, 1, MPI_INT32_T);
 
-    // Set element -> material ID mapping on each Nek rank
-    for (int i = 0; i < n_global_elem_; ++i) {
-      elem_to_mat_[i] = mat_idx[i];
+    // Set element -> cell instance mapping on each Nek rank
+    for (gsl::index i = 0; i < n_global_elem_; ++i) {
+      elem_to_cell_[i] = cell_idx[i];
     }
-
-    // Step 3: Map material indices to positions in heat array
-    // Each Nek rank needs to know where to find heat source values in an array.
-    // This requires knowing a mapping of material indices to positions in the
-    // heat array (of size n_materials_). For this mapping, we use a direct
-    // address table and begin by filling it with zeros.
-    heat_index_.reserve(n_materials_);
-    std::fill_n(std::back_inserter(heat_index_), n_materials_, 0);
-
-    // Now, set the mapping values on the OpenMC processes...
-    if (openmc_driver_->active()) {
-      for (int i = 0; i < n_materials_; ++i) {
-        int32_t mat_index = openmc_driver_->cells_[i].material_index_;
-        heat_index_.at(mat_index) = i;
-      }
-    }
-
-    // ...and broadcast to the other Nek processes
-    intranode_comm_.Bcast(heat_index_.data(), n_materials_, MPI_INT);
   }
 }
 
@@ -202,8 +184,9 @@ void OpenmcNekDriver::init_temperatures()
       // the correct index in the temperatures_ array. This mapping assumes that
       // each Nek element is fully contained within an OpenMC cell, i.e. Nek elements
       // are not split between multiple OpenMC cells.
-      for (const auto& c : openmc_driver_->cells_) {
-        const auto& global_elems = mat_to_elems_.at(c.material_index_);
+      for (gsl::index i = 0; i < openmc_driver_->cells_.size(); ++i) {
+        const auto& global_elems = cell_to_elems_.at(i);
+        const auto& c = openmc_driver_->cells_[i];
 
         for (int elem : global_elems) {
           double T = c.get_temperature();
@@ -264,9 +247,9 @@ void OpenmcNekDriver::init_densities()
       // the correct index in the densities_ array. This mapping assumes that
       // each Nek element is fully contained within an OpenMC cell, i.e. Nek
       // elements are not split between multiple OpenMC cells.
-      for (int i = 0; i < openmc_driver_->cells_.size(); ++i) {
+      for (gsl::index i = 0; i < openmc_driver_->cells_.size(); ++i) {
         auto& c = openmc_driver_->cells_[i];
-        const auto& global_elems = mat_to_elems_.at(c.material_index_);
+        const auto& global_elems = cell_to_elems_.at(i);
 
         if (cell_fluid_mask_[i] == 1) {
           for (int elem : global_elems) {
@@ -323,8 +306,8 @@ void OpenmcNekDriver::init_cell_fluid_mask()
     auto& cells = openmc_driver_->cells_;
     cell_fluid_mask_.resize({cells.size()});
 
-    for (int i = 0; i < cells.size(); ++i) {
-      auto elems = mat_to_elems_.at(cells[i].material_index_);
+    for (gsl::index i = 0; i < cells.size(); ++i) {
+      auto elems = cell_to_elems_.at(i);
       for (const auto& j : elems) {
         if (elem_fluid_mask_[j] == 1) {
           cell_fluid_mask_[i] = 1;
@@ -338,15 +321,15 @@ void OpenmcNekDriver::init_cell_fluid_mask()
 
 void OpenmcNekDriver::init_heat_source()
 {
-  heat_source_ = xt::empty<double>({n_materials_});
-  heat_source_prev_ = xt::empty<double>({n_materials_});
+  heat_source_ = xt::empty<double>({n_cells_});
+  heat_source_prev_ = xt::empty<double>({n_cells_});
 }
 
 void OpenmcNekDriver::set_heat_source()
 {
   // OpenMC has heat source on each of its ranks. We need to make heat
   // source available on each Nek rank.
-  intranode_comm_.Bcast(heat_source_.data(), n_materials_, MPI_DOUBLE);
+  intranode_comm_.Bcast(heat_source_.data(), n_cells_, MPI_DOUBLE);
 
   if (nek_driver_->active()) {
     // Determine displacement for this rank
@@ -357,12 +340,12 @@ void OpenmcNekDriver::set_heat_source()
       // get corresponding global element
       int global_index = local_elem + displacement - 1;
 
-      // get corresponding material
-      int32_t mat_index = elem_to_mat_.at(global_index);
-      int i = heat_index_.at(mat_index);
+      // get index to cell instance
+      int32_t cell_index = elem_to_cell_.at(global_index);
 
-      err_chk(nek_driver_->set_heat_source_at(local_elem, heat_source_[i]),
-              "Error setting heat source for local element " + std::to_string(i));
+      err_chk(nek_driver_->set_heat_source_at(local_elem, heat_source_[cell_index]),
+              "Error setting heat source for local element " +
+                std::to_string(local_elem));
     }
   }
 }
@@ -374,13 +357,14 @@ void OpenmcNekDriver::set_temperature()
       // Broadcast global_element_temperatures onto all the OpenMC procs
       openmc_driver_->comm_.Bcast(temperatures_.data(), n_global_elem_, MPI_DOUBLE);
 
-      // For each OpenMC material, volume average temperatures and set
-      for (const auto& c : openmc_driver_->cells_) {
+      // For each OpenMC cell instance, volume average temperatures and set
+      for (size_t i = 0; i < openmc_driver_->cells_.size(); ++i) {
 
         // Get corresponding global elements
-        const auto& global_elems = mat_to_elems_.at(c.material_index_);
+        const auto& global_elems = cell_to_elems_.at(i);
+        auto& c{openmc_driver_->cells_[i]};
 
-        // Get volume-average temperature for this material
+        // Get volume-average temperature for this cell instance
         double average_temp = 0.0;
         double total_vol = 0.0;
         for (int elem : global_elems) {
@@ -420,14 +404,15 @@ void OpenmcNekDriver::update_density()
     if (openmc_driver_->active()) {
       openmc_driver_->comm_.Bcast(densities_.data(), n_global_elem_, MPI_DOUBLE);
 
-      // For each OpenMC material in a fluid cell, volume average the densities and set
+      // For each OpenMC cell instance in a fluid cell, volume average the
+      // densities and set
       // TODO:  Might be able to use xtensor masking to do some of this
       for (int i = 0; i < openmc_driver_->cells_.size(); ++i) {
         if (cell_fluid_mask_[i] == 1) {
           auto& c = openmc_driver_->cells_[i];
           double average_density = 0.0;
           double total_vol = 0.0;
-          for (int e : mat_to_elems_.at(c.material_index_)) {
+          for (int e : cell_to_elems_.at(i)) {
             average_density += densities_[e] * elem_volumes_[e];
             total_vol += elem_volumes_[e];
           }

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -83,6 +83,8 @@ void OpenmcNekDriver::init_mpi_datatypes()
 
 void OpenmcNekDriver::init_mappings()
 {
+  comm_.message("Initializing mappings");
+
   if (this->has_global_coupling_data()) {
     elem_centroids_.resize(n_global_elem_);
     elem_fluid_mask_.resize({n_global_elem_});
@@ -162,6 +164,8 @@ void OpenmcNekDriver::init_mappings()
 
 void OpenmcNekDriver::init_tallies()
 {
+  comm_.message("Initializing tallies");
+
   if (openmc_driver_->active()) {
     // Build vector of material indices
     std::vector<int32_t> mats;
@@ -174,6 +178,8 @@ void OpenmcNekDriver::init_tallies()
 
 void OpenmcNekDriver::init_temperatures()
 {
+  comm_.message("Initializing temperatures");
+
   if (this->has_global_coupling_data()) {
     temperatures_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
     temperatures_prev_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
@@ -210,6 +216,8 @@ void OpenmcNekDriver::init_temperatures()
 
 void OpenmcNekDriver::init_volumes()
 {
+  comm_.message("Initializing volumes");
+
   if (this->has_global_coupling_data()) {
     elem_volumes_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
@@ -237,6 +245,8 @@ void OpenmcNekDriver::init_volumes()
 
 void OpenmcNekDriver::init_densities()
 {
+  comm_.message("Initializing densities");
+
   if (this->has_global_coupling_data()) {
     densities_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
     densities_prev_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
@@ -280,6 +290,8 @@ void OpenmcNekDriver::init_densities()
 
 void OpenmcNekDriver::init_elem_fluid_mask()
 {
+  comm_.message("Initializing element fluid mask");
+
   if (this->has_global_coupling_data()) {
     elem_fluid_mask_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
@@ -302,6 +314,8 @@ void OpenmcNekDriver::init_elem_fluid_mask()
 
 void OpenmcNekDriver::init_cell_fluid_mask()
 {
+  comm_.message("Initializing cell fluid mask");
+
   if (nek_driver_->active() && openmc_driver_->active()) {
     auto& cells = openmc_driver_->cells_;
     cell_fluid_mask_.resize({cells.size()});
@@ -321,6 +335,8 @@ void OpenmcNekDriver::init_cell_fluid_mask()
 
 void OpenmcNekDriver::init_heat_source()
 {
+  comm_.message("Initializing heat source");
+
   heat_source_ = xt::empty<double>({n_cells_});
   heat_source_prev_ = xt::empty<double>({n_cells_});
 }


### PR DESCRIPTION
This change stemmed from a bug that I found when trying to run our coupled short assembly model. Namely, `heat_index_` was being allocated to be the size of `openmc_driver_->cells_` (i.e., the number of materials that are found by searching using Nek5000 element centroids) but was then being indexed with an OpenMC material index (which might be larger than the size of `cells_`. My fix was to just use the index in `cells_` instead, since the cell instance knows its corresponding material index. After making this change, I realized that `heat_index_` is was not actually needed at all anymore, so it has been removed.

Along with this change, I've renamed all the mappings to reference "cells" rather than "materials". I'm planning on implementing a "cell instance" filter in OpenMC that will allow us to get tallies on separate cell instances that might share the same material. Right now, materials have to be duplicated. By having the mappings based on cell instances rather than materials, we should be able to switch over seamlessly to the (not yet implemented) cell instance filter once it is available.