### PR TITLE
Move power normalization into ShiftDriver

### DIFF
--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -15,17 +15,10 @@ public:
     : Driver(comm)
   {}
 
-  //! Get energy deposition in each material
+  //! Get energy deposition in each material normalized to a given power
   //! \param power User-specified power in [W]
   //! \return Heat source in each material as [W/cm3]
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
-
-  //! Normalize the heat source by a given power. By default, this method does not
-  //! perform any normalization. This method may also include unit conversions
-  //! if necessary.
-  //! \param heat_source Heat source to be normalized
-  //! \param power Total integrated power with which to normalize [W]
-  virtual void normalize_heat_source(xt::xtensor<double, 1>& heat_source, double power) const {}
 };
 
 } // namespace enrico

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -31,9 +31,6 @@ public:
 
   xt::xtensor<double, 1> heat_source(double power) const final;
 
-  void normalize_heat_source(xt::xtensor<double, 1>& heat_source,
-                             double power) const final;
-
   //! Initialization required in each Picard iteration
   void init_step() final;
 

--- a/include/smrt/shift_driver.h
+++ b/include/smrt/shift_driver.h
@@ -83,9 +83,6 @@ public:
   // get the heat source normalized to the given total power
   std::vector<double> heat_source(double power) const;
 
-  // normalize the power tally to the given total power
-  void normalize_heat_source(std::vector<double>& heat_source, double power) const;
-
 private:
   // Add power tally to parameter list
   void add_power_tally(RCP_PL& pl, const std::vector<double>& z_edges);

--- a/include/smrt/shift_driver.h
+++ b/include/smrt/shift_driver.h
@@ -55,6 +55,9 @@ private:
   int d_num_materials;
   std::vector<int> d_matids;
 
+  // Power density indexed by cell ID
+  std::vector<double> d_power_by_cell_ID;
+
   // Map from Shift geometric cells to T/H elements
   int d_num_shift_cells;
   std::vector<std::vector<int>> d_power_map;
@@ -76,6 +79,12 @@ public:
   void solve(const std::vector<double>& th_temperature,
              const std::vector<double>& coolant_density,
              std::vector<double>& power) override;
+
+  // get the heat source normalized to the given total power
+  std::vector<double> heat_source(double power) const;
+
+  // normalize the power tally to the given total power
+  void normalize_heat_source(std::vector<double>& heat_source, double power) const;
 
 private:
   // Add power tally to parameter list

--- a/include/smrt/shift_driver.h
+++ b/include/smrt/shift_driver.h
@@ -55,9 +55,6 @@ private:
   int d_num_materials;
   std::vector<int> d_matids;
 
-  // Power density indexed by cell ID
-  std::vector<double> d_power_by_cell_ID;
-
   // Map from Shift geometric cells to T/H elements
   int d_num_shift_cells;
   std::vector<std::vector<int>> d_power_map;

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -55,6 +55,9 @@ private:
   std::vector<double> d_densities;
   std::vector<double> d_powers;
 
+  // Power indexed by shift cell ID
+  std::vector<double> d_power_shift;
+
 
 public:
   // Constructor
@@ -71,9 +74,6 @@ public:
   void solve();
 
 private:
-  // Normalize power distribution to appropriate value
-  void normalize_power();
-
   // Map "standard" types to corresponding MPI types
   template<typename T>
   MPI_Datatype get_mpi_type() const

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -60,17 +60,8 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
   auto mean_value = xt::view(tally_->results_, xt::all(), 0, openmc::RESULT_SUM);
   xt::xtensor<double, 1> heat = JOULE_PER_EV * mean_value / m;
 
-  // Normalize the heat source
-  normalize_heat_source(heat, power);
-
-  return heat;
-}
-
-void OpenmcDriver::normalize_heat_source(xt::xtensor<double, 1>& heat_source,
-                                         double power) const
-{
   // Get total heat production [J/source]
-  double total_heat = xt::sum(heat_source)();
+  double total_heat = xt::sum(heat)();
 
   for (int i = 0; i < cells_.size(); ++i) {
     // Get volume
@@ -79,8 +70,10 @@ void OpenmcDriver::normalize_heat_source(xt::xtensor<double, 1>& heat_source,
     // Convert heat from [J/source] to [W/cm^3]. Dividing by total_heat gives
     // the fraction of heat deposited in each material. Multiplying by power
     // givens an absolute value in W
-    heat_source(i) *= power / (total_heat * V);
+    heat(i) *= power / (total_heat * V);
   }
+
+  return heat;
 }
 
 void OpenmcDriver::init_step()

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -66,6 +66,8 @@ std::vector<double> ShiftDriver::heat_source(double power) const
   auto shift_seq = std::dynamic_pointer_cast<omnibus::Sequence_Shift>(sequence);
   const auto& tallies = shift_seq->tallies();
 
+  std::vector<double> d_power_by_cell_ID;
+
   const auto& cell_tallies = tallies.cell_tallies();
   for (const auto& tally : cell_tallies) {
     if (tally->name() == d_power_tally_name) {

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -85,13 +85,6 @@ std::vector<double> ShiftDriver::heat_source(double power) const
     }
   }
 
-  normalize_heat_source(d_power_by_cell_ID, power);
-
-  return d_power_by_cell_ID;
-}
-
-void ShiftDriver::normalize_heat_source(std::vector<double>& heat_source, double power) const
-{
   double total_power = 0.0;
   for (int cellid = 0; cellid < d_power_by_cell_ID.size(); ++cellid) {
     total_power += d_power_by_cell_ID[cellid] * d_geometry->cell_volume(cellid);
@@ -99,8 +92,11 @@ void ShiftDriver::normalize_heat_source(std::vector<double>& heat_source, double
   nemesis::global_sum(total_power);
 
   double norm_factor = power / total_power;
-  for (auto& val : heat_source)
+  for (auto& val : d_power_by_cell_ID)
     val *= norm_factor;
+
+
+  return d_power_by_cell_ID;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -66,7 +66,7 @@ std::vector<double> ShiftDriver::heat_source(double power) const
   auto shift_seq = std::dynamic_pointer_cast<omnibus::Sequence_Shift>(sequence);
   const auto& tallies = shift_seq->tallies();
 
-  std::vector<double> d_power_by_cell_ID;
+  std::vector<double> power_by_cell_ID;
 
   const auto& cell_tallies = tallies.cell_tallies();
   for (const auto& tally : cell_tallies) {
@@ -82,23 +82,23 @@ std::vector<double> ShiftDriver::heat_source(double power) const
 
       for (int cellid = 0; cellid < mean.size(); ++cellid) {
         double tally_volume = d_geometry->cell_volume(cellid);
-        d_power_by_cell_ID.push_back(mean[cellid] / tally_volume / total_power);
+        power_by_cell_ID.push_back(mean[cellid] / tally_volume / total_power);
       }
     }
   }
 
   double total_power = 0.0;
-  for (int cellid = 0; cellid < d_power_by_cell_ID.size(); ++cellid) {
-    total_power += d_power_by_cell_ID[cellid] * d_geometry->cell_volume(cellid);
+  for (int cellid = 0; cellid < power_by_cell_ID.size(); ++cellid) {
+    total_power += power_by_cell_ID[cellid] * d_geometry->cell_volume(cellid);
   }
   nemesis::global_sum(total_power);
 
   double norm_factor = power / total_power;
-  for (auto& val : d_power_by_cell_ID)
+  for (auto& val : power_by_cell_ID)
     val *= norm_factor;
 
 
-  return d_power_by_cell_ID;
+  return power_by_cell_ID;
 }
 
 //---------------------------------------------------------------------------//

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -95,8 +95,8 @@ void ShiftNekDriver::solve()
   for (int iteration = 0; iteration < max_picard_iter_; ++iteration) {
     // Set heat source in Nek; first, get heat source indexed by cell ID
     // from Shift and map it to Nek elements
-    for (int cellid = 0; cellid < d_power_map.size(); ++cellid) {
-      const auto& elem_list = d_power_map[cellid];
+    for (int cellid = 0; cellid < d_shift_solver->d_power_map.size(); ++cellid) {
+      const auto& elem_list = d_shift_solver->d_power_map[cellid];
 
       for (const auto& elem : elem_list)
         d_powers[elem] = d_power_shift[cellid];


### PR DESCRIPTION
For the neutronics smrt drivers to act as "black-boxes," they shouldn't require any data mapping information from Nek/surrogates. This MR moves the power normalization into `ShiftDriver` based on the Shift geometry (i.e. according to cell volumes). The `ShiftNekDriver` is changed to grab the power from the Shift driver and apply it to Nek's elements according to the established coupling mappings.

In the future, I see this progressing to the point where `d_power_map` is not created by `ShiftDriver` at all, but instead in `ShiftNekDriver`, since it reflects coupling info, not single-physics info.

I haven't compiled this yet FYI, so this is just a proposed idea.