### PR TITLE
Remove surrogate-surrogate coupling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ if (SCALE_FOUND)
         src/smrt/Assembly_Model.cpp
         src/smrt/shift_nek_driver.cpp
         src/smrt/surrogate_heat_fluid_driver.cpp
-        src/smrt/Multiphysics_Driver.cpp
+        src/smrt/shift_heat_fluids_driver.cpp
         src/smrt/shift_driver.cpp
         src/smrt/smrt_coupled_driver.cpp
         src/smrt/Single_Pin_Conduction.cpp

--- a/include/smrt/shift_heat_fluids_driver.hpp
+++ b/include/smrt/shift_heat_fluids_driver.hpp
@@ -1,5 +1,5 @@
-#ifndef Multiphysics_Driver_h
-#define Multiphysics_Driver_h
+#ifndef ShiftHeatFluidsDriver_h
+#define ShiftHeatFluidsDriver_h
 
 #include <memory>
 #include <vector>
@@ -16,17 +16,17 @@ namespace enrico {
 
 //===========================================================================//
 /*!
- * \class Multiphysics_Driver
+ * \class ShiftHeatFluidsDriver
  * \brief Simple driver for multiphysics coupling.
  */
 /*!
  * \example Driver/test/tstMultiphysics_Driver.cc
  *
- * Test of Multiphysics_Driver.
+ * Test of ShiftHeatFluidsDriver.
  */
 //===========================================================================//
 
-class Multiphysics_Driver {
+class ShiftHeatFluidsDriver {
 public:
   //@{
   //! Typedefs
@@ -59,7 +59,7 @@ private:
 
 public:
   // Constructor
-  Multiphysics_Driver(SP_Assembly assembly, RCP_PL params, const Vec_Dbl& dz);
+  ShiftHeatFluidsDriver(SP_Assembly assembly, RCP_PL params, const Vec_Dbl& dz);
 
   // Solve problem
   void solve();
@@ -75,8 +75,8 @@ public:
 } // end namespace enrico
 
 //---------------------------------------------------------------------------//
-#endif // Multiphysics_Driver_h
+#endif // ShiftHeatFluidsDriver_h
 
 //---------------------------------------------------------------------------//
-// end of Multiphysics_Driver.h
+// end of ShiftHeatFluidsDriver.h
 //---------------------------------------------------------------------------//

--- a/src/smrt/shift_heat_fluids_driver.cpp
+++ b/src/smrt/shift_heat_fluids_driver.cpp
@@ -1,14 +1,14 @@
 //---------------------------------*-C++-*-----------------------------------//
 /*!
- * \file   Multiphysics_Driver.cpp
+ * \file   ShiftHeatFluidsDriver.cpp
  * \author Steven Hamilton
  * \date   Fri Aug 10 09:00:11 2018
- * \brief  Multiphysics_Driver class definitions.
+ * \brief  ShiftHeatFluidsDriver class definitions.
  * \note   Copyright (c) 2018 Oak Ridge National Laboratory, UT-Battelle, LLC.
  */
 //---------------------------------------------------------------------------//
 
-#include "smrt/Multiphysics_Driver.h"
+#include "smrt/ShiftHeatFluidsDriver.h"
 
 // SCALE includes
 #include "Nemesis/comm/Logger.hh"
@@ -20,7 +20,6 @@
 #include <gsl/gsl>
 
 // enrico includes
-#include "smrt/Two_Group_Diffusion.h"
 #ifdef USE_SHIFT
 #include "smrt/shift_driver.h"
 #endif
@@ -29,7 +28,7 @@ namespace enrico {
 //---------------------------------------------------------------------------//
 // Constructor
 //---------------------------------------------------------------------------//
-Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
+ShiftHeatFluidsDriver::ShiftHeatFluidsDriver(SP_Assembly assembly,
                                          RCP_PL params,
                                          const Vec_Dbl& z_edges)
   : d_assembly(assembly)
@@ -37,6 +36,11 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
   Expects(assembly != nullptr);
 
   Expects(nemesis::soft_equiv(z_edges.back(), d_assembly->height()));
+
+  // shift must be enabled in this build if this class constructor is called
+  #ifndef USE_SHIFT
+    Expects(false);
+  #endif
 
   Vec_Dbl dz(z_edges.size() - 1);
   for (int edge = 0; edge < dz.size(); ++edge)
@@ -67,27 +71,15 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
 
   // Build neutronics solver (surrogate diffusion or Shift MC)
   auto neutronics_params = Teuchos::sublist(params, "Neutronics");
-  auto neutronics_type =
-    neutronics_params->get("neutronics_type", std::string("diffusion"));
-  if (neutronics_type == "diffusion") {
-    d_neutronics = std::make_shared<Two_Group_Diffusion>(assembly, neutronics_params, dz);
-  } else {
-#ifdef USE_SHIFT
-    // Neutronics type set to 'shift', but no 'shift_input' specified
-    Expects(neutronics_params->isType<std::string>("shift_input"));
-    auto shift_input = neutronics_params->get<std::string>("shift_input");
-    d_neutronics = std::make_shared<ShiftDriver>(assembly, shift_input, z_edges);
-#else
-    // Neutronics type set to 'shift', but Shift is not enabled in this build.
-    Expects(false);
-#endif
+  auto shift_input = neutronics_params->get<std::string>("shift_input");
+  d_neutronics = std::make_shared<ShiftDriver>(assembly, shift_input, z_edges);
   }
 }
 
 //---------------------------------------------------------------------------//
 // Solve
 //---------------------------------------------------------------------------//
-void Multiphysics_Driver::solve()
+void ShiftHeatFluidsDriver::solve()
 {
   // Set initial guess for power
   std::fill(d_power.begin(), d_power.end(), 0.0);
@@ -182,5 +174,5 @@ void Multiphysics_Driver::solve()
 } // end namespace enrico
 
 //---------------------------------------------------------------------------//
-// end of Driver/Multiphysics_Driver.cc
+// end of Driver/ShiftHeatFluidsDriver.cc
 //---------------------------------------------------------------------------//

--- a/src/smrt/shift_heat_fluids_driver.cpp
+++ b/src/smrt/shift_heat_fluids_driver.cpp
@@ -1,6 +1,6 @@
 //---------------------------------*-C++-*-----------------------------------//
 /*!
- * \file   ShiftHeatFluidsDriver.cpp
+ * \file   shift_heat_fluids_driver.cpp
  * \author Steven Hamilton
  * \date   Fri Aug 10 09:00:11 2018
  * \brief  ShiftHeatFluidsDriver class definitions.
@@ -8,7 +8,7 @@
  */
 //---------------------------------------------------------------------------//
 
-#include "smrt/ShiftHeatFluidsDriver.h"
+#include "smrt/shift_heat_fluids_driver.hpp"
 
 // SCALE includes
 #include "Nemesis/comm/Logger.hh"
@@ -174,5 +174,5 @@ void ShiftHeatFluidsDriver::solve()
 } // end namespace enrico
 
 //---------------------------------------------------------------------------//
-// end of Driver/ShiftHeatFluidsDriver.cc
+// end of smrt/shift_heat_fluids_driver.cpp
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This MR removes surrogate-surrogate coupling in `smrt` to match convention used elsewhere in this project by having each coupled-physics driver drive only two (pre-defined) applications. Previously, `Multiphysics_Driver` selected the neutronics solver in its constructor. This is removed so that `Multiphysics_Driver` only couples Shift and a T/H surrogate (and hence is renamed to `ShiftHeatFluidsDriver`.

This may break some tests or input files on the ORNL side that used the `Multiphysics_Driver` constructor to select the neutronics solver - that selection should be moved outside to a `main.cpp` or some other higher-level driver (I just don't have access to that yet).