### PR TITLE
Remove some of the nemesis dependencies

### DIFF
--- a/include/enrico/utils.h
+++ b/include/enrico/utils.h
@@ -1,0 +1,29 @@
+#ifndef ENRICO_UTILS_H
+#define ENRICO_UTILS_H
+
+#include <cmath>
+
+namespace enrico {
+
+//! Compare two numbers for
+inline bool soft_equiv(double value, double reference)
+{
+  constexpr double rel_precision = 1e-12;
+  constexpr double abs_threshold = 1e-14;
+
+  // Typical case: relative error comparison to reference
+  if (std::abs(value - reference) < rel_precision * std::abs(reference)) {
+    return true;
+  }
+
+  // If one is within the absolute threshold of zero, and the other within
+  // relative of zero, they're equal
+  if ((std::abs(reference) < abs_threshold) && (std::abs(value) < rel_precision)) {
+    return true;
+  }
+  return (std::abs(value) < abs_threshold) && (std::abs(reference) < rel_precision);
+}
+
+} // namespace enrico
+
+#endif // ENRICO_UTILS_H

--- a/src/smrt/Assembly_Model.cpp
+++ b/src/smrt/Assembly_Model.cpp
@@ -1,9 +1,6 @@
 #include "smrt/Assembly_Model.h"
 
-// SCALE includes
-#include "Nemesis/utils/Constants.hh"
-
-// vendored includes
+#include "openmc/constants.h"
 #include <gsl/gsl>
 
 namespace enrico {
@@ -85,7 +82,7 @@ double Assembly_Model::flow_area(int i, int j) const
     r = d_guide_radius;
   Expects(r > 0.0);
 
-  double area = dx * dy - nemesis::constants::pi * r * r;
+  double area = dx * dy - openmc::PI * r * r;
   Ensures(area > 0);
   return area;
 }

--- a/src/smrt/Multiphysics_Driver.cpp
+++ b/src/smrt/Multiphysics_Driver.cpp
@@ -13,13 +13,13 @@
 // SCALE includes
 #include "Nemesis/comm/Logger.hh"
 #include "Nemesis/comm/global.hh"
-#include "Nemesis/harness/Soft_Equivalence.hh"
 #include "Omnibus/config.h"
 
 // vendored includes
 #include <gsl/gsl>
 
 // enrico includes
+#include "enrico/utils.h"
 #include "smrt/Two_Group_Diffusion.h"
 #ifdef USE_SHIFT
 #include "smrt/shift_driver.h"
@@ -36,7 +36,7 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
 {
   Expects(assembly != nullptr);
 
-  Expects(nemesis::soft_equiv(z_edges.back(), d_assembly->height()));
+  Expects(soft_equiv(z_edges.back(), d_assembly->height()));
 
   Vec_Dbl dz(z_edges.size() - 1);
   for (int edge = 0; edge < dz.size(); ++edge)
@@ -62,8 +62,8 @@ Multiphysics_Driver::Multiphysics_Driver(SP_Assembly assembly,
   // Build fluids-heat solver
   auto subchannel_params = Teuchos::sublist(params, "Subchannel");
   auto conduction_params = Teuchos::sublist(params, "Conduction");
-  d_heat_fluid = std::make_shared<SurrogateHeatFluidDriver>(assembly, subchannel_params,
-    conduction_params, dz);
+  d_heat_fluid = std::make_shared<SurrogateHeatFluidDriver>(
+    assembly, subchannel_params, conduction_params, dz);
 
   // Build neutronics solver (surrogate diffusion or Shift MC)
   auto neutronics_params = Teuchos::sublist(params, "Neutronics");

--- a/src/smrt/Single_Pin_Conduction.cpp
+++ b/src/smrt/Single_Pin_Conduction.cpp
@@ -1,9 +1,9 @@
 #include <cmath>
 #include <iostream>
 
+#include "enrico/utils.h"
 #include "smrt/Single_Pin_Conduction.h"
 
-#include "Nemesis/harness/Soft_Equivalence.hh"
 #include "Nemesis/utils/String_Functions.hh"
 #include "openmc/constants.h"
 
@@ -56,7 +56,7 @@ void Single_Pin_Conduction::solve(const std::vector<double>& power,
   dr = (d_clad_radius - d_fuel_radius) / static_cast<double>(num_rings_clad);
   for (int r = num_rings_fuel; r < num_rings; ++r)
     radius[r + 1] = radius[r] + dr;
-  Expects(nemesis::soft_equiv(radius[num_rings], d_clad_radius));
+  Expects(soft_equiv(radius[num_rings], d_clad_radius));
 
   // Assign thermal conductivity in fuel and clad
   std::vector<double> k(num_rings);
@@ -70,10 +70,10 @@ void Single_Pin_Conduction::solve(const std::vector<double>& power,
   }
   // Check areas
   double fuel_area = std::accumulate(area.begin(), area.begin() + num_rings_fuel, 0.0);
-  Expects(nemesis::soft_equiv(fuel_area, PI * d_fuel_radius * d_fuel_radius));
+  Expects(soft_equiv(fuel_area, PI * d_fuel_radius * d_fuel_radius));
 
   double total_area = std::accumulate(area.begin(), area.end(), 0.0);
-  Expects(nemesis::soft_equiv(total_area, PI * d_clad_radius * d_clad_radius));
+  Expects(soft_equiv(total_area, PI * d_clad_radius * d_clad_radius));
 
   auto rcp_matrix = Teuchos::rcp(new Matrix(num_rings, num_rings));
   auto rcp_rhs = Teuchos::rcp(new Vector(num_rings));

--- a/src/smrt/Single_Pin_Subchannel.cpp
+++ b/src/smrt/Single_Pin_Subchannel.cpp
@@ -3,10 +3,8 @@
 
 #include "smrt/Single_Pin_Subchannel.h"
 
-// SCALE includes
-#include "Nemesis/utils/String_Functions.hh"
-
 // vendored includes
+#include "openmc/string_utils.h"
 #include <gsl/gsl>
 #include <iapws.h>
 
@@ -28,7 +26,8 @@ Single_Pin_Subchannel::Single_Pin_Subchannel(RCP_PL& parameters,
   for (auto& val : d_delta_z)
     val *= 1e-2;
 
-  auto verb = nemesis::lower(parameters->get("verbosity", std::string("none")));
+  auto verb = parameters->get("verbosity", std::string("none"));
+  openmc::to_lower(verb);
   if (verb == "none") {
     d_verbosity = NONE;
   } else if (verb == "low") {

--- a/src/smrt/shift_driver.cpp
+++ b/src/smrt/shift_driver.cpp
@@ -10,6 +10,7 @@
 
 #include <map>
 
+#include "enrico/utils.h"
 #include "smrt/shift_driver.h"
 
 #include "Teuchos_DefaultComm.hpp"
@@ -97,7 +98,6 @@ std::vector<double> ShiftDriver::heat_source(double power) const
   for (auto& val : power_by_cell_ID)
     val *= norm_factor;
 
-
   return power_by_cell_ID;
 }
 
@@ -116,7 +116,6 @@ void ShiftDriver::solve(const std::vector<double>& th_temperature,
   // Rebuild problem (loading any new data needed and run transport
   d_driver->rebuild();
   d_driver->run();
-
 }
 
 void ShiftDriver::update_temperature(const std::vector<double>& temperatures)
@@ -234,8 +233,7 @@ void ShiftDriver::add_power_tally(RCP_PL& pl, const std::vector<double>& z_edges
     Validate(x_tally.size() == x_edges.size(),
              "Tally specifies incorrect size of x edges");
     for (int i = 0; i < x_edges.size(); ++i)
-      Validate(nemesis::soft_equiv(x_edges[i], x_tally[i]),
-               "Tally specifies incorrect x edge");
+      Validate(soft_equiv(x_edges[i], x_tally[i]), "Tally specifies incorrect x edge");
 
     // Check y edges
     const auto& y_edges = d_assembly->y_edges();
@@ -243,16 +241,14 @@ void ShiftDriver::add_power_tally(RCP_PL& pl, const std::vector<double>& z_edges
     Validate(y_tally.size() == y_edges.size(),
              "Tally specifies incorrect size of y edges");
     for (int i = 0; i < y_edges.size(); ++i)
-      Validate(nemesis::soft_equiv(y_edges[i], y_tally[i]),
-               "Tally specifies incorrect y edge");
+      Validate(soft_equiv(y_edges[i], y_tally[i]), "Tally specifies incorrect y edge");
 
     // Check z edges
     const auto& z_tally = power_pl->get<Array_Dbl>("z");
     Validate(z_tally.size() == z_edges.size(),
              "Tally specifies incorrect size of z edges");
     for (int i = 0; i < z_edges.size(); ++i)
-      Validate(nemesis::soft_equiv(z_edges[i], z_tally[i]),
-               "Tally specifies incorrect z edge");
+      Validate(soft_equiv(z_edges[i], z_tally[i]), "Tally specifies incorrect z edge");
   }
 }
 

--- a/src/smrt/surrogate_heat_fluid_driver.cpp
+++ b/src/smrt/surrogate_heat_fluid_driver.cpp
@@ -1,8 +1,8 @@
 #include <algorithm>
 
+#include "enrico/utils.h"
 #include "smrt/SurrogateHeatFluidDriver.h"
 
-#include "Nemesis/harness/Soft_Equivalence.hh"
 #include <gsl/gsl>
 
 namespace enrico {
@@ -18,7 +18,7 @@ SurrogateHeatFluidDriver::SurrogateHeatFluidDriver(SP_Assembly assembly,
   Expects(d_assembly != nullptr);
 
   double height = std::accumulate(dz.begin(), dz.end(), 0.0);
-  Expects(nemesis::soft_equiv(height, d_assembly->height()));
+  Expects(soft_equiv(height, d_assembly->height()));
 
   double mdot_per_area = subchannel_parameters->get("mass_flow_rate", 0.4);
 


### PR DESCRIPTION
This PR removes some of the `nemesis` dependencies:

- `soft_equiv` is replaced with a simplified version in `enrico/utils.h`
- `constants::pi` is replaced with `openmc::PI`
- `lower` is replaced with `openmc::to_lower`