### PR TITLE
Fix mapping of OpenMC cell instances to Nek elements

### DIFF
--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -135,7 +135,7 @@ private:
   //! element index. The Nek global element indices refer to indices defined by
   //! the MPI_Gatherv operation, and do not reflect Nek's internal global
   //! element indexing.
-  std::unordered_map<int, int32_t> elem_to_cell_;
+  std::vector<int32_t> elem_to_cell_;
 
   //! Number of cell instances in OpenMC model
   int32_t n_cells_;

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -3,9 +3,11 @@
 #include "enrico/const.h"
 #include "enrico/error.h"
 #include "enrico/message_passing.h"
+
 #include "gsl/gsl"
 #include "nek5000/core/nek_interface.h"
 #include "openmc/capi.h"
+#include "openmc/cell.h"
 #include "pugixml.hpp"
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xtensor.hpp"
@@ -253,8 +255,8 @@ void OpenmcNekDriver::init_volumes()
         v_nek += elem_volumes_.at(elem);
       }
       std::stringstream msg;
-      msg << "Cell " << c.index_ << " (" << c.instance_ << "), V = " << v_openmc
-          << " (OpenMC), " << v_nek << " (Nek)";
+      msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
+          << "), V = " << v_openmc << " (OpenMC), " << v_nek << " (Nek)";
       comm_.message(msg.str());
     }
   }

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -242,6 +242,22 @@ void OpenmcNekDriver::init_volumes()
       openmc_driver_->comm_.Bcast(elem_volumes_.data(), n_global_elem_, MPI_DOUBLE);
     }
   }
+
+  // Volume check
+  if (this->has_global_coupling_data()) {
+    for (gsl::index i = 0; i < openmc_driver_->cells_.size(); ++i) {
+      const auto& c = openmc_driver_->cells_[i];
+      double v_openmc = c.volume_;
+      double v_nek = 0.0;
+      for (const auto& elem : cell_to_elems_.at(i)) {
+        v_nek += elem_volumes_.at(elem);
+      }
+      std::stringstream msg;
+      msg << "Cell " << c.index_ << " (" << c.instance_ << "), V = " << v_openmc
+          << " (OpenMC), " << v_nek << " (Nek)";
+      comm_.message(msg.str());
+    }
+  }
 }
 
 void OpenmcNekDriver::init_densities()


### PR DESCRIPTION
There was evidently a bug in the OpenMC-Nek mapping introduced by #39 (namely, [this line](https://github.com/enrico-dev/enrico/blob/bb4f302d4820841e484745cfacf14179bca719de/src/openmc_nek_driver.cpp#L142)). This PR fixes that bug and adds a volume check that shows the volumes reported by OpenMC and Nek that can help to identify such issues in the future.