### PR TITLE
Check fissionable cells in Openmc-surrogate

### DIFF
--- a/include/enrico/cell_instance.h
+++ b/include/enrico/cell_instance.h
@@ -38,6 +38,10 @@ public:
   //! \return cell density in [g/cm^3]
   double get_density() const;
 
+  //! Check if the cell is fissionable
+  //! \return whether the cell contains fissionable material
+  bool is_fissionable() const;
+
   //! Check for equality
   bool operator==(const CellInstance& other) const;
 

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -49,6 +49,7 @@ public:
   openmc::Tally* tally_;            //!< Fission energy deposition tally
   int32_t index_filter_;            //!< Index in filters arrays for material filter
   std::vector<CellInstance> cells_; //!< Array of cell instances
+  int n_fissionable_cells_;         //!< Number of fissionable cells in model
 };
 
 } // namespace enrico

--- a/src/cell_instance.cpp
+++ b/src/cell_instance.cpp
@@ -60,6 +60,13 @@ double CellInstance::get_density() const
   return rho;
 }
 
+bool CellInstance::is_fissionable() const
+{
+  bool fissionable;
+  err_chk(openmc_material_get_fissionable(material_index_, &fissionable));
+  return fissionable;
+}
+
 bool CellInstance::operator==(const CellInstance& other) const
 {
   return index_ == other.index_ && instance_ == other.instance_;

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -24,14 +24,14 @@ OpenmcDriver::OpenmcDriver(MPI_Comm comm)
   // determine number of fissionable cells in model to aid in catching
   // improperly mapped problems
   n_fissionable_cells_ = 0;
-  for (int i = 0; i < cells_size(); ++i) {
+  for (gsl::index i = 0; i < openmc::model::cells.size(); ++i) {
     int type;
     int32_t* indices;
     int32_t n;
     err_chk(openmc_cell_get_fill(i, &type, &indices, &n));
 
     // only check for cells filled with type FILL_MATERIAL (evaluated to '1' enum)
-    if (type == 1) {
+    if (type == openmc::FILL_MATERIAL) {
       for (int j = 0; j < n; ++j) {
         int material_index = indices[j];
 

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -4,6 +4,7 @@
 #include "enrico/error.h"
 
 #include "openmc/capi.h"
+#include "openmc/cell.h"
 #include "openmc/constants.h"
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -104,7 +104,7 @@ void OpenmcHeatDriver::init_mappings()
           if (k < heat_driver_->n_fuel_rings_) {
             Ensures(c.is_fissionable());
           } else {
-             Ensures(!c.is_fissionable());
+            Ensures(!c.is_fissionable());
           }
 
           // Map OpenMC material to ring and vice versa

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -89,6 +89,19 @@ void OpenmcHeatDriver::init_mappings()
             tracked[c] = openmc_driver_->cells_.size() - 1;
           }
 
+          // ensure that the cell being mapped for the pellet region contains
+          // a fissionable material as a way to check that the T/H geometry of the
+          // pellet region is sufficiently refined to account for all OpenMC cells.
+          // This check does not ensure that we have accounted for
+          // _all_ fissionable cells, just that the models line up in the pellet region,
+          // from which we can infer that the general geometry lines up (because otherwise
+          // we could be mapping fluid cells to the surrogate pins, etc.)
+          if (k < heat_driver_->n_fuel_rings_) {
+            Ensures(c.is_fissionable());
+          } else {
+             Ensures(!c.is_fissionable());
+          }
+
           // Map OpenMC material to ring and vice versa
           int32_t array_index = tracked[c];
           cell_inst_to_ring_[array_index].push_back(ring_index);

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -56,6 +56,8 @@ void OpenmcHeatDriver::init_mappings()
   // TODO: Don't hardcode number of azimuthal segments
   int n_azimuthal = 4;
 
+  int n_fissionable_mapped = 0;
+
   for (int i = 0; i < heat_driver_->n_pins_; ++i) {
     // Get coordinate of pin center
     double x_center = heat_driver_->pin_centers_(i, 0);
@@ -87,6 +89,9 @@ void OpenmcHeatDriver::init_mappings()
           if (tracked.find(c) == tracked.end()) {
             openmc_driver_->cells_.push_back(c);
             tracked[c] = openmc_driver_->cells_.size() - 1;
+
+            if (k < heat_driver_->n_fuel_rings_)
+              n_fissionable_mapped++;
           }
 
           // ensure that the cell being mapped for the pellet region contains
@@ -112,6 +117,12 @@ void OpenmcHeatDriver::init_mappings()
       }
     }
   }
+
+  // check that all fissionable cells have been mapped to the T/H model.
+  // Note that this does not check for distortions in the model, just that
+  // the surrogate T/H model is sufficiently fine in the pellet region to
+  // capture all fissionable cells in OpenMC.
+  Ensures(openmc_driver_->n_fissionable_cells_ == n_fissionable_mapped);
 
   if (openmc_driver_->active()) {
     n_materials_ = openmc_driver_->cells_.size();


### PR DESCRIPTION
This MR adds two sanity checks to the `OpenmcHeatDriver::init_mappings()`:

1. The number of tracked OpenMC cells in the pellet regions must equal the number of total fissionable cells. This ensures that the surrogate mesh is sufficiently fine to "find" all the OpenMC cells with our collocation-type search. This implicitly assumes you'll be coupling anywhere you have fissionable material.

2. The cells in the pellet and cladding should be fissionable and not fissionable, respectively. This additional check helps ensure that the models line up geometrically by matching OpenMC fissile cells to where those cells actually are in the T/H model.

Marked as WIP until !1310 in OpenMC is merged to access the `cells_size()` method.