### PR TITLE
Use subchannel in OpenmcHeatDriver

### DIFF
--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -34,6 +34,8 @@ public:
 
   void set_temperature() override;
 
+  void update_density() override;
+
   NeutronicsDriver& get_neutronics_driver() const override;
 
   HeatFluidsDriver & get_heat_driver() const override;
@@ -42,8 +44,14 @@ public:
   std::unordered_map<int, std::vector<int>> ring_to_cell_inst_;
   std::unordered_map<int, std::vector<int>> cell_inst_to_ring_;
 
+  // Mapping of surrogate fluid elements to OpenMC cell instances and vice versa
+  std::unordered_map<int, std::vector<int>> elem_to_cell_inst_;
+  std::unordered_map<int, std::vector<int>> cell_inst_to_elem_;
+
 protected:
   void init_temperatures() override;
+
+  void init_densities() override;
 
   void init_heat_source() override;
 
@@ -61,7 +69,11 @@ private:
 
   std::unique_ptr<SurrogateHeatDriver> heat_driver_; //!< The heat surrogate driver
 
-  int32_t n_materials_; //! Number of materials in OpenMC model
+  //! Number of OpenMC cells that are solid
+  int32_t n_solid_cells_;
+
+  //! Number of OpenMC cells that are fluid
+  int32_t n_fluid_cells_;
 };
 
 } // namespace enrico

--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -45,7 +45,7 @@ public:
   std::unordered_map<int, std::vector<int>> cell_inst_to_ring_;
 
   // Mapping of surrogate fluid elements to OpenMC cell instances and vice versa
-  std::unordered_map<int, std::vector<int>> elem_to_cell_inst_;
+  std::vector<std::vector<int>> elem_to_cell_inst_;
   std::unordered_map<int, std::vector<int>> cell_inst_to_elem_;
 
 protected:

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -220,7 +220,7 @@ public:
   xt::xtensor<int, 1> fluid_mask() const final;
 
   //! Returns solid temperature in [K] for given region
-  double solid_temperature(int pin, int axial, int ring) const;
+  double solid_temperature(std::size_t pin, std::size_t axial, std::size_t ring) const;
 
   // Data on fuel pins
   xt::xtensor<double, 2> pin_centers_; //!< (x,y) values for center of fuel pins

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -219,8 +219,8 @@ public:
 
   xt::xtensor<int, 1> fluid_mask() const final;
 
-  //! Returns temperature in [K] for given region
-  double temperature(int pin, int axial, int ring) const;
+  //! Returns solid temperature in [K] for given region
+  double solid_temperature(int pin, int axial, int ring) const;
 
   // Data on fuel pins
   xt::xtensor<double, 2> pin_centers_; //!< (x,y) values for center of fuel pins
@@ -251,6 +251,9 @@ public:
   xt::xtensor<double, 3> source_;      //!< heat source for each (axial segment, ring)
   xt::xtensor<double, 1> r_grid_clad_; //!< radii of each clad ring in [cm]
   xt::xtensor<double, 1> r_grid_fuel_; //!< radii of each fuel ring in [cm]
+
+  //! Cross-sectional areas of rings in fuel and cladding
+  xt::xtensor<double, 1> solid_areas_;
 
   // visualization
   std::string viz_basename_{
@@ -291,28 +294,19 @@ private:
   bool is_energy_conserved(const xt::xtensor<double, 2>& rho, const xt::xtensor<double, 2>& u,
     const xt::xtensor<double, 2>&h, const xt::xtensor<double, 2>& q) const;
 
-  //!< temperature in [K] for each (pin, axial segment, ring)
-  xt::xtensor<double, 3> temperature_;
+  //!< solid temperature in [K] for each (pin, axial segment, ring)
+  xt::xtensor<double, 3> solid_temperature_;
 
-  //!< density in [g/cm^3] for each (pin, axial segment, ring)
-  xt::xtensor<double, 3> density_;
-
-  //! Value is 1 if (pin, axial segment, ring) region is in fluid; otherwise 0
-  //!
-  //! Because the surrogate only solves heat and only represents solid, this whole xtensor
-  //! == 0
-  xt::xtensor<int, 3> fluid_mask_;
+  //! Value is 1 if region is in fluid; otherwise 0
+  xt::xtensor<int, 1> fluid_mask_;
 
   //! Flow areas for coolant-centered channels
   xt::xtensor<double, 1> channel_areas_;
 
-  //! Cross-sectional areas of rings in fuel and cladding
-  xt::xtensor<double, 1> solid_areas_;
-
   //! Fluid temperature in a rod-centered basis indexed by rod ID and axial ID
   xt::xtensor<double, 2> fluid_temperature_;
 
-  //! Fluid density in a rod-centered basis indexed by rod ID and axial ID
+  //! Fluid density in [g/cm^3] in a rod-centered basis indexed by rod ID and axial ID
   xt::xtensor<double, 2> fluid_density_;
 
   //! Number of pins in the x-direction in a Cartesian grid

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -33,7 +33,7 @@ OpenmcDriver::OpenmcDriver(MPI_Comm comm)
 
     // only check for cells filled with type FILL_MATERIAL (evaluated to '1' enum)
     if (type == openmc::FILL_MATERIAL) {
-      for (int j = 0; j < n; ++j) {
+      for (gsl::index j = 0; j < n; ++j) {
         int material_index = indices[j];
 
         // skip cells filled with type MATERIAL_VOID (evaluated to '-1' enum)
@@ -88,7 +88,7 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
   // Get total heat production [J/source]
   double total_heat = xt::sum(heat)();
 
-  for (int i = 0; i < heat.size(); ++i) {
+  for (gsl::index i = 0; i < heat.size(); ++i) {
     // Get volume
     double V = cells_.at(i).volume_;
 

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -74,7 +74,7 @@ void OpenmcDriver::create_tallies(gsl::span<int32_t> materials)
 
 xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
 {
-  // Determine number of realizatoins for normalizing tallies
+  // Determine number of realizations for normalizing tallies
   int m = tally_->n_realizations_;
 
   // Broadcast number of realizations
@@ -88,7 +88,7 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
   // Get total heat production [J/source]
   double total_heat = xt::sum(heat)();
 
-  for (int i = 0; i < cells_.size(); ++i) {
+  for (int i = 0; i < heat.size(); ++i) {
     // Get volume
     double V = cells_.at(i).volume_;
 

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -133,7 +133,7 @@ void OpenmcHeatDriver::init_mappings()
 
   // set the number of solid cells before defining mappings for fluid cells
   if (openmc_driver_->active()) {
-    n_solid_cells_ = openmc_driver_->cells_.size();
+    n_solid_cells_ = gsl::narrow<int>(openmc_driver_->cells_.size());
   }
 
   // Establish mappings between fluid regions and OpenMC cells; it is assumed that there
@@ -156,7 +156,7 @@ void OpenmcHeatDriver::init_mappings()
       CellInstance c{r};
       if (tracked.find(c) == tracked.end()) {
         openmc_driver_->cells_.push_back(c);
-        tracked[c] = openmc_driver_->cells_.size() - 1;
+        tracked[c] = gsl::narrow<int>(openmc_driver_->cells_.size() - 1);
 
         Ensures(!c.is_fissionable());
       }
@@ -171,7 +171,7 @@ void OpenmcHeatDriver::init_mappings()
   }
 
   if (openmc_driver_->active()) {
-    n_fluid_cells_ = openmc_driver_->cells_.size() - n_solid_cells_;
+    n_fluid_cells_ = gsl::narrow<int>(openmc_driver_->cells_.size() - n_solid_cells_);
   }
 }
 

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -25,6 +25,7 @@ OpenmcHeatDriver::OpenmcHeatDriver(MPI_Comm comm, pugi::xml_node node)
   init_tallies();
 
   init_temperatures();
+  init_densities();
   init_heat_source();
 }
 
@@ -52,22 +53,28 @@ void OpenmcHeatDriver::init_mappings()
   const auto& z = heat_driver_->z_;
 
   std::unordered_map<CellInstance, int> tracked;
+
+  // index for rings in solid
   int ring_index = 0;
+
+  // index for elements in fluid
+  int elem_index = 0;
+
   // TODO: Don't hardcode number of azimuthal segments
   int n_azimuthal = 4;
 
   int n_fissionable_mapped = 0;
 
+  // Establish mappings between solid regions and OpenMC cells. The center
+  // coordinate for each region in the T/H model is obtained and used to
+  // determine the OpenMC cell at that position.
   for (int i = 0; i < heat_driver_->n_pins_; ++i) {
-    // Get coordinate of pin center
     double x_center = heat_driver_->pin_centers_(i, 0);
     double y_center = heat_driver_->pin_centers_(i, 1);
 
     for (int j = 0; j < heat_driver_->n_axial_; ++j) {
-      // Get average z value
       double zavg = 0.5 * (z(j) + z(j + 1));
 
-      // Loop over radial rings
       for (int k = 0; k < heat_driver_->n_rings(); ++k) {
         double ravg;
         if (k < heat_driver_->n_fuel_rings_) {
@@ -124,36 +131,137 @@ void OpenmcHeatDriver::init_mappings()
   // capture all fissionable cells in OpenMC.
   Ensures(openmc_driver_->n_fissionable_cells_ == n_fissionable_mapped);
 
+  // set the number of solid cells before defining mappings for fluid cells
   if (openmc_driver_->active()) {
-    n_materials_ = openmc_driver_->cells_.size();
+    n_solid_cells_ = openmc_driver_->cells_.size();
+  }
+
+  // Establish mappings between fluid regions and OpenMC cells; it is assumed that there
+  // are no azimuthal divisions in the fluid phase in the OpenMC model so that we
+  // can take a point on a 45 degree ray from the pin center. TODO: add a check to make
+  // sure that the T/H model is finer than the OpenMC model.
+  for (int i = 0; i < heat_driver_->n_pins_; ++i) {
+    double x_center = heat_driver_->pin_centers_(i, 0);
+    double y_center = heat_driver_->pin_centers_(i, 1);
+
+    for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+      double zavg = 0.5 * (z(j) + z(j + 1));
+      double l = heat_driver_->pin_pitch() / std::sqrt(2.0);
+      double d = (l - heat_driver_->clad_outer_radius_) / 2.0;
+      double x = x_center + (heat_driver_->clad_outer_radius_ + d) * std::sqrt(2.0) / 2.0;
+      double y = y_center + (heat_driver_->clad_outer_radius_ + d) * std::sqrt(2.0) / 2.0;
+
+      // Determine cell instance corresponding to given fluid location
+      Position r{x, y, zavg};
+      CellInstance c{r};
+      if (tracked.find(c) == tracked.end()) {
+        openmc_driver_->cells_.push_back(c);
+        tracked[c] = openmc_driver_->cells_.size() - 1;
+
+        Ensures(!c.is_fissionable());
+      }
+
+      // Map OpenMC material to fluid element and vice versa
+      int32_t array_index = tracked[c];
+      cell_inst_to_elem_[array_index].push_back(elem_index);
+      elem_to_cell_inst_[elem_index].push_back(array_index);
+
+      ++elem_index;
+    }
+  }
+
+  if (openmc_driver_->active()) {
+    n_fluid_cells_ = openmc_driver_->cells_.size() - n_solid_cells_;
   }
 }
 
 void OpenmcHeatDriver::init_tallies()
 {
   if (openmc_driver_->active()) {
-    // Build vector of material indices
+    // Build vector of material indices to construct tallies; tallies are only
+    // used in the solid regions
     std::vector<int32_t> mats;
-    for (const auto& c : openmc_driver_->cells_) {
-      mats.push_back(c.material_index_);
+    for (int c = 0; c < n_solid_cells_; ++c) {
+      const auto& cell = openmc_driver_->cells_[c];
+      mats.push_back(cell.material_index_);
     }
+
     openmc_driver_->create_tallies(mats);
+  }
+}
+
+void OpenmcHeatDriver::init_densities()
+{
+  if (this->has_global_coupling_data()) {
+    std::size_t n_solid =
+      heat_driver_->n_pins_ * heat_driver_->n_axial_ * heat_driver_->n_rings();
+    std::size_t n_fluid = heat_driver_->n_pins_ * heat_driver_->n_axial_;
+    densities_.resize({n_solid + n_fluid});
+    densities_prev_.resize({n_solid + n_fluid});
+
+    if (density_ic_ == Initial::neutronics) {
+      // Loop over all of the fluid regions in the heat transfer model and set
+      // the density IC based on the densities used in the OpenMC input file. Set
+      // the initial solid density to 0.0 because it is not used in the simulation
+      // at all anyways.
+      int ring_index = 0;
+      for (int i = 0; i < heat_driver_->n_pins_; ++i) {
+        for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+          for (int k = 0; k < heat_driver_->n_rings(); ++k, ++ring_index) {
+            densities_(ring_index) = 0.0;
+          }
+        }
+      }
+
+      int elem_index = 0;
+      int solid_offset = ring_index;
+      for (int i = 0; i < heat_driver_->n_pins_; ++i) {
+        for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+
+          double rho_avg = 0.0;
+          double total_vol = 0.0;
+
+          for (const auto& idx : elem_to_cell_inst_[elem_index++]) {
+            const auto& c = openmc_driver_->cells_[idx];
+            double vol = c.volume_;
+
+            total_vol += vol;
+            rho_avg += c.get_density() * vol;
+          }
+
+          densities_(elem_index + solid_offset) = rho_avg / total_vol;
+        }
+      }
+
+      std::copy(densities_.begin(), densities_.end(), densities_prev_.begin());
+    }
+
+    if (density_ic_ == Initial::heat) {
+      throw std::runtime_error{
+        "Density initial conditions from surrogate heat-fluids "
+        "solver not supported."};
+    }
   }
 }
 
 void OpenmcHeatDriver::init_temperatures()
 {
   if (this->has_global_coupling_data()) {
-    std::size_t n =
+    std::size_t n_solid =
       heat_driver_->n_pins_ * heat_driver_->n_axial_ * heat_driver_->n_rings();
-    temperatures_.resize({n});
-    temperatures_prev_.resize({n});
+    std::size_t n_fluid = heat_driver_->n_pins_ * heat_driver_->n_axial_;
+    temperatures_.resize({n_solid + n_fluid});
+    temperatures_prev_.resize({n_solid + n_fluid});
 
     if (temperature_ic_ == Initial::neutronics) {
       // Loop over all of the rings in the heat transfer model and set the temperature IC
       // based on temperatures used in the OpenMC input file. More than one OpenMC cell
       // may correspond to a particular ring, so the initial temperature set for that ring
-      // should be a volume average of the OpenMC cell temperatures.
+      // should be a volume average of the OpenMC cell temperatures. Then, loop over all
+      // axial fluid cells for each pin and set the fluid temperature IC based on the
+      // fluid temperature in the OpenMC model. No more than one OpenMC cell should correspond
+      // to a given axial fluid cell, so no averaging is needed (though we retain the averaging
+      // syntax below: TODO - update elem_to_cell_inst_ to permit multiple OpenMC cells per axial.
 
       // TODO: This initial condition used in the coupled driver does not truly represent
       // the actual initial condition used in the OpenMC input file, since the surrogate
@@ -165,11 +273,14 @@ void OpenmcHeatDriver::init_temperatures()
       // the azimuthal segments in the OpenMC model are all the same (i.e. no initial
       // azimuthal dependence).
 
+      int index = 0;
+
+      // set temperatures for solid cells
       int ring_index = 0;
       for (int i = 0; i < heat_driver_->n_pins_; ++i) {
         for (int j = 0; j < heat_driver_->n_axial_; ++j) {
           for (int k = 0; k < heat_driver_->n_rings(); ++k) {
-            const auto& cell_instances = ring_to_cell_inst_[ring_index];
+            const auto& cell_instances = ring_to_cell_inst_[ring_index++];
 
             double T_avg = 0.0;
             double total_vol = 0.0;
@@ -182,16 +293,35 @@ void OpenmcHeatDriver::init_temperatures()
               T_avg += c.get_temperature() * vol;
             }
 
-            T_avg /= total_vol;
-
-            int t_index = (i * heat_driver_->n_axial_ + j) * heat_driver_->n_rings() + k;
-            temperatures_prev_[t_index] = T_avg;
-            temperatures_[t_index] = T_avg;
-
-            ++ring_index;
+            temperatures_[index] = T_avg / total_vol;
+            ++index;
           }
         }
       }
+
+      // set temperatures for fluid cells
+      int axial_index = 0;
+      for (int i = 0; i < heat_driver_->n_pins_; ++i) {
+        for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+          const auto& cell_instances = elem_to_cell_inst_[axial_index++];
+
+          double T_avg = 0.0;
+          double total_vol = 0.0;
+
+          for (auto idx : cell_instances) {
+            const auto& c = openmc_driver_->cells_[idx];
+            double vol = c.volume_;
+
+            total_vol += vol;
+            T_avg += c.get_temperature() * vol;
+          }
+
+          temperatures_[index] = T_avg / total_vol;
+          ++index;
+        }
+      }
+
+      std::copy(temperatures_.begin(), temperatures_.end(), temperatures_prev_.begin());
     }
 
     if (temperature_ic_ == Initial::heat) {
@@ -204,8 +334,8 @@ void OpenmcHeatDriver::init_temperatures()
 
 void OpenmcHeatDriver::init_heat_source()
 {
-  heat_source_ = xt::empty<double>({n_materials_});
-  heat_source_prev_ = xt::empty<double>({n_materials_});
+  heat_source_ = xt::empty<double>({n_solid_cells_});
+  heat_source_prev_ = xt::empty<double>({n_solid_cells_});
 }
 
 void OpenmcHeatDriver::set_heat_source()
@@ -238,41 +368,72 @@ void OpenmcHeatDriver::set_heat_source()
   }
 }
 
+void OpenmcHeatDriver::update_density()
+{
+  if (this->has_global_coupling_data()) {
+    std::copy(densities_.begin(), densities_.end(), densities_prev_.begin());
+  }
+
+  densities_ = heat_driver_->density();
+  int solid_offset = heat_driver_->n_pins_ * heat_driver_->n_rings() * heat_driver_->n_axial_;
+
+  for (int i = 0; i < n_fluid_cells_; ++i) {
+    int index = i + n_solid_cells_;
+    const auto& c = openmc_driver_->cells_[index];
+    const auto& elems = cell_inst_to_elem_[index];
+
+    double average_rho = 0.0;
+    double total_vol = 0.0;
+    for (int elem_index : elems) {
+      double vol = heat_driver_->z_(elem_index + 1) - heat_driver_->z_(elem_index);
+      average_rho += densities_(elem_index + solid_offset);
+      total_vol += vol;
+    }
+
+    c.set_density(average_rho / total_vol);
+  }
+}
+
 void OpenmcHeatDriver::set_temperature()
 {
   const auto& r_fuel = heat_driver_->r_grid_fuel_;
   const auto& r_clad = heat_driver_->r_grid_clad_;
 
-  // For each OpenMC material, volume average temperatures and set
-  for (int i = 0; i < openmc_driver_->cells_.size(); ++i) {
-    // Get cell instance
+  // For each OpenMC solid cell, volume average solid temperatures and set
+  // by grabbing the T/H regions corresponding to the cell
+  for (int i = 0; i < n_solid_cells_; ++i) {
     const auto& c = openmc_driver_->cells_[i];
-
-    // Get rings corresponding to this cell instance
     const auto& rings = cell_inst_to_ring_[i];
 
-    // Get volume-average temperature for this material
     double average_temp = 0.0;
     double total_vol = 0.0;
     for (int ring_index : rings) {
-      // Use difference in r**2 as a proxy for volume. This is only used for
-      // averaging, so the absolute value doesn't matter
-      int j = ring_index % heat_driver_->n_rings();
-      double vol;
-      if (j < heat_driver_->n_fuel_rings_) {
-        vol = r_fuel(j + 1) * r_fuel(j + 1) - r_fuel(j) * r_fuel(j);
-      } else {
-        j -= heat_driver_->n_fuel_rings_;
-        vol = r_clad(j + 1) * r_clad(j + 1) - r_clad(j) * r_clad(j);
-      }
-
+      double vol = heat_driver_->solid_areas_(ring_index);
       average_temp += temperatures_(ring_index) * vol;
       total_vol += vol;
     }
-    average_temp /= total_vol;
 
-    // Set temperature for cell instance
+    average_temp /= total_vol;
     c.set_temperature(average_temp);
+  }
+
+  // For each OpenMC fluid cell, set the fluid temperature by grabbing
+  // the T/H region corresponding to the cell
+  int solid_offset = heat_driver_->n_pins_ * heat_driver_->n_rings() * heat_driver_->n_axial_;
+  for (int i = 0; i < n_fluid_cells_; ++i) {
+    int index = n_solid_cells_ + i;
+    const auto& c = openmc_driver_->cells_[index];
+    const auto& elems = cell_inst_to_elem_[index];
+
+    double average_temp = 0.0;
+    double total_vol = 0.0;
+    for (int elem_index : elems) {
+      double vol = heat_driver_->z_(elem_index + 1) - heat_driver_->z_(elem_index);
+      average_temp += temperatures_(elem_index + solid_offset) * vol;
+      total_vol += vol;
+    }
+
+    c.set_temperature(average_temp / total_vol);
   }
 }
 

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -68,14 +68,14 @@ void OpenmcHeatDriver::init_mappings()
   // Establish mappings between solid regions and OpenMC cells. The center
   // coordinate for each region in the T/H model is obtained and used to
   // determine the OpenMC cell at that position.
-  for (int i = 0; i < heat_driver_->n_pins_; ++i) {
+  for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
     double x_center = heat_driver_->pin_centers_(i, 0);
     double y_center = heat_driver_->pin_centers_(i, 1);
 
-    for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+    for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
       double zavg = 0.5 * (z(j) + z(j + 1));
 
-      for (int k = 0; k < heat_driver_->n_rings(); ++k) {
+      for (gsl::index k = 0; k < heat_driver_->n_rings(); ++k) {
         double ravg;
         if (k < heat_driver_->n_fuel_rings_) {
           ravg = 0.5 * (r_fuel(k) + r_fuel(k + 1));
@@ -84,7 +84,7 @@ void OpenmcHeatDriver::init_mappings()
           ravg = 0.5 * (r_clad(m) + r_clad(m + 1));
         }
 
-        for (int m = 0; m < n_azimuthal; ++m) {
+        for (gsl::index m = 0; m < n_azimuthal; ++m) {
           double m_avg = m + 0.5;
           double theta = 2.0 * m_avg * PI / n_azimuthal;
           double x = x_center + ravg * std::cos(theta);
@@ -140,11 +140,11 @@ void OpenmcHeatDriver::init_mappings()
   // are no azimuthal divisions in the fluid phase in the OpenMC model so that we
   // can take a point on a 45 degree ray from the pin center. TODO: add a check to make
   // sure that the T/H model is finer than the OpenMC model.
-  for (int i = 0; i < heat_driver_->n_pins_; ++i) {
+  for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
     double x_center = heat_driver_->pin_centers_(i, 0);
     double y_center = heat_driver_->pin_centers_(i, 1);
 
-    for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+    for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
       double zavg = 0.5 * (z(j) + z(j + 1));
       double l = heat_driver_->pin_pitch() / std::sqrt(2.0);
       double d = (l - heat_driver_->clad_outer_radius_) / 2.0;
@@ -181,7 +181,7 @@ void OpenmcHeatDriver::init_tallies()
     // Build vector of material indices to construct tallies; tallies are only
     // used in the solid regions
     std::vector<int32_t> mats;
-    for (int c = 0; c < n_solid_cells_; ++c) {
+    for (gsl::index c = 0; c < n_solid_cells_; ++c) {
       const auto& cell = openmc_driver_->cells_[c];
       mats.push_back(cell.material_index_);
     }
@@ -205,9 +205,9 @@ void OpenmcHeatDriver::init_densities()
       // the initial solid density to 0.0 because it is not used in the simulation
       // at all anyways.
       int ring_index = 0;
-      for (int i = 0; i < heat_driver_->n_pins_; ++i) {
-        for (int j = 0; j < heat_driver_->n_axial_; ++j) {
-          for (int k = 0; k < heat_driver_->n_rings(); ++k, ++ring_index) {
+      for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
+        for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
+          for (gsl::index k = 0; k < heat_driver_->n_rings(); ++k, ++ring_index) {
             densities_(ring_index) = 0.0;
           }
         }
@@ -215,8 +215,8 @@ void OpenmcHeatDriver::init_densities()
 
       int elem_index = 0;
       int solid_offset = ring_index;
-      for (int i = 0; i < heat_driver_->n_pins_; ++i) {
-        for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+      for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
+        for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
 
           double rho_avg = 0.0;
           double total_vol = 0.0;
@@ -277,9 +277,9 @@ void OpenmcHeatDriver::init_temperatures()
 
       // set temperatures for solid cells
       int ring_index = 0;
-      for (int i = 0; i < heat_driver_->n_pins_; ++i) {
-        for (int j = 0; j < heat_driver_->n_axial_; ++j) {
-          for (int k = 0; k < heat_driver_->n_rings(); ++k) {
+      for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
+        for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
+          for (gsl::index k = 0; k < heat_driver_->n_rings(); ++k) {
             const auto& cell_instances = ring_to_cell_inst_[ring_index++];
 
             double T_avg = 0.0;
@@ -301,8 +301,8 @@ void OpenmcHeatDriver::init_temperatures()
 
       // set temperatures for fluid cells
       int axial_index = 0;
-      for (int i = 0; i < heat_driver_->n_pins_; ++i) {
-        for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+      for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
+        for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
           const auto& cell_instances = elem_to_cell_inst_[axial_index++];
 
           double T_avg = 0.0;
@@ -345,10 +345,10 @@ void OpenmcHeatDriver::set_heat_source()
     val = 0.0;
 
   int ring_index = 0;
-  for (int i = 0; i < heat_driver_->n_pins_; ++i) {
-    for (int j = 0; j < heat_driver_->n_axial_; ++j) {
+  for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
+    for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
       // Loop over radial rings
-      for (int k = 0; k < heat_driver_->n_rings(); ++k) {
+      for (gsl::index k = 0; k < heat_driver_->n_rings(); ++k) {
         // Only update heat source in fuel
         if (k < heat_driver_->n_fuel_rings_) {
           // Get average Q value across each azimuthal segment
@@ -375,16 +375,16 @@ void OpenmcHeatDriver::update_density()
   }
 
   densities_ = heat_driver_->density();
-  int solid_offset = heat_driver_->n_pins_ * heat_driver_->n_rings() * heat_driver_->n_axial_;
+  auto solid_offset = heat_driver_->n_pins_ * heat_driver_->n_rings() * heat_driver_->n_axial_;
 
-  for (int i = 0; i < n_fluid_cells_; ++i) {
+  for (gsl::index i = 0; i < n_fluid_cells_; ++i) {
     int index = i + n_solid_cells_;
     const auto& c = openmc_driver_->cells_[index];
     const auto& elems = cell_inst_to_elem_[index];
 
     double average_rho = 0.0;
     double total_vol = 0.0;
-    for (int elem_index : elems) {
+    for (auto elem_index : elems) {
       double vol = heat_driver_->z_(elem_index + 1) - heat_driver_->z_(elem_index);
       average_rho += densities_(elem_index + solid_offset);
       total_vol += vol;
@@ -401,13 +401,13 @@ void OpenmcHeatDriver::set_temperature()
 
   // For each OpenMC solid cell, volume average solid temperatures and set
   // by grabbing the T/H regions corresponding to the cell
-  for (int i = 0; i < n_solid_cells_; ++i) {
+  for (gsl::index i = 0; i < n_solid_cells_; ++i) {
     const auto& c = openmc_driver_->cells_[i];
     const auto& rings = cell_inst_to_ring_[i];
 
     double average_temp = 0.0;
     double total_vol = 0.0;
-    for (int ring_index : rings) {
+    for (auto ring_index : rings) {
       double vol = heat_driver_->solid_areas_(ring_index);
       average_temp += temperatures_(ring_index) * vol;
       total_vol += vol;
@@ -419,15 +419,15 @@ void OpenmcHeatDriver::set_temperature()
 
   // For each OpenMC fluid cell, set the fluid temperature by grabbing
   // the T/H region corresponding to the cell
-  int solid_offset = heat_driver_->n_pins_ * heat_driver_->n_rings() * heat_driver_->n_axial_;
-  for (int i = 0; i < n_fluid_cells_; ++i) {
+  auto solid_offset = heat_driver_->n_pins_ * heat_driver_->n_rings() * heat_driver_->n_axial_;
+  for (gsl::index i = 0; i < n_fluid_cells_; ++i) {
     int index = n_solid_cells_ + i;
     const auto& c = openmc_driver_->cells_[index];
     const auto& elems = cell_inst_to_elem_[index];
 
     double average_temp = 0.0;
     double total_vol = 0.0;
-    for (int elem_index : elems) {
+    for (auto elem_index : elems) {
       double vol = heat_driver_->z_(elem_index + 1) - heat_driver_->z_(elem_index);
       average_temp += temperatures_(elem_index + solid_offset) * vol;
       total_vol += vol;

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -195,13 +195,15 @@ void SurrogateHeatDriver::generate_arrays()
 
   // Create empty arrays for source term and temperature in the solid phase
   source_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
-  temperature_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
-  density_ = xt::zeros<double>({n_pins_, n_axial_, n_rings()});
-  fluid_mask_ = xt::zeros<int>({n_pins_, n_axial_, n_rings()});
+  solid_temperature_ = xt::empty<double>({n_pins_, n_axial_, n_rings()});
 
   // Create empty arrays for temperature and density in the fluid phase
   fluid_temperature_ = xt::empty<double>({n_pins_, n_axial_});
   fluid_density_ = xt::empty<double>({n_pins_, n_axial_});
+
+  xt::xtensor<int, 1> s_mask({n_pins_ * n_axial_ * n_rings()}, 0);
+  xt::xtensor<int, 1> f_mask({n_pins_ * n_axial_}, 1);
+  fluid_mask_ = xt::concatenate(xt::xtuple(s_mask, f_mask), 0);
 }
 
 double SurrogateHeatDriver::rod_axial_node_power(const int pin, const int axial) const
@@ -416,7 +418,7 @@ void SurrogateHeatDriver::solve_heat()
       double T_co = fluid_temperature_(i, j);
 
       // Set initial temperature to surface temperature
-      xt::view(temperature_, i, j) = T_co;
+      xt::view(solid_temperature_, i, j) = T_co;
 
       solve_steady_nonlin(&q(i, j, 0),
                           T_co,
@@ -425,29 +427,33 @@ void SurrogateHeatDriver::solve_heat()
                           n_fuel_rings_,
                           n_clad_rings_,
                           heat_tol_,
-                          &temperature_(i, j, 0));
+                          &solid_temperature_(i, j, 0));
     }
   }
 }
 
 xt::xtensor<double, 1> SurrogateHeatDriver::temperature() const
 {
-  return xt::flatten(temperature_);
+  xt::xarray<double> Ts = {xt::flatten(solid_temperature_)};
+  xt::xarray<double> Tf = {xt::flatten(fluid_temperature_)};
+  return xt::concatenate(xt::xtuple(Ts, Tf), 0);
 }
 
-double SurrogateHeatDriver::temperature(int pin, int axial, int ring) const
+double SurrogateHeatDriver::solid_temperature(int pin, int axial, int ring) const
 {
-  return temperature_(pin, axial, ring);
+  return solid_temperature_(pin, axial, ring);
 }
 
 xt::xtensor<double, 1> SurrogateHeatDriver::density() const
 {
-  return xt::flatten(density_);
+  xt::xarray<double> rhos({n_pins_ * n_axial_ * n_rings()}, 0.0);
+  xt::xarray<double> rhof = {xt::flatten(fluid_density_)};
+  return xt::concatenate(xt::xtuple(rhos, rhof), 0);
 }
 
 xt::xtensor<int, 1> SurrogateHeatDriver::fluid_mask() const
 {
-  return xt::flatten(fluid_mask_);
+  return fluid_mask_;
 }
 
 void SurrogateHeatDriver::write_step(int timestep, int iteration)

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -439,7 +439,7 @@ xt::xtensor<double, 1> SurrogateHeatDriver::temperature() const
   return xt::concatenate(xt::xtuple(Ts, Tf), 0);
 }
 
-double SurrogateHeatDriver::solid_temperature(int pin, int axial, int ring) const
+double SurrogateHeatDriver::solid_temperature(std::size_t pin, std::size_t axial, std::size_t ring) const
 {
   return solid_temperature_(pin, axial, ring);
 }

--- a/src/vtk_viz.cpp
+++ b/src/vtk_viz.cpp
@@ -254,7 +254,7 @@ void SurrogateVtkWriter::write_data(ofstream& vtk_file)
         for (size_t i = 0; i < n_axial_sections_; i++) {
           for (size_t j = 0; j < n_radial_fuel_sections_; j++) {
             for (size_t k = 0; k < radial_res_; k++) {
-              vtk_file << surrogate_.temperature(pin, i, j) << "\n";
+              vtk_file << surrogate_.solid_temperature(pin, i, j) << "\n";
             }
           }
         }
@@ -265,7 +265,7 @@ void SurrogateVtkWriter::write_data(ofstream& vtk_file)
         for (size_t i = 0; i < n_axial_sections_; i++) {
           for (size_t j = 0; j < n_radial_clad_sections_; j++) {
             for (size_t k = 0; k < radial_res_; k++) {
-              vtk_file << surrogate_.temperature(pin, i, j + n_radial_fuel_sections_)
+              vtk_file << surrogate_.solid_temperature(pin, i, j + n_radial_fuel_sections_)
                        << "\n";
             }
           }


### PR DESCRIPTION
This MR adds use of the subchannel fluid temperature and density solutions in OpenMC for the `OpenmcHeatDriver`. Auxiliary features include:

1. Ability to set initial density based on OpencMC model
2. Ability to set initial fluid temperature based on OpenMC model

This MR doesn't include any checks on convergence based on density or fluid temperature, which I think should be added as a separate commit. In the design here, I found it easier to work with temperatures and densities for the fluid and solid separately so that not a whole lot of reworking was needed for the existing solid solution. This results in the `fluid_mask` being un-used. I think this is fine for now, but I envision in the future moving `fluid_mask` out of the T/H base class and into `NekDriver`, _or_ changing the internals of `SurrogateHeatDriver` to make it necessary to use. 

This is marked as WIP until !58 is merged because I found the additional cell fissionable checks to be useful in debugging.