### PR TITLE
Integer types in Nek interface, drivers

### DIFF
--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -61,7 +61,7 @@ public:
   //!
   //! \param local_elem The local index of the desired element
   //! \return The dimensionless coordinate of the element's centroid
-  Position centroid_at(int local_elem) const;
+  Position centroid_at(int32_t local_elem) const;
 
   //! Get the volume of a local element
   //!
@@ -70,7 +70,7 @@ public:
   //!
   //! \param local_elem The local index of the desired element
   //! \return The dimensionless Volume of the element
-  double volume_at(int local_elem) const;
+  double volume_at(int32_t local_elem) const;
 
   //! Get the volume-averaged temperature of a local element
   //!
@@ -80,12 +80,12 @@ public:
   //!
   //! \param local_elem A local element ID
   //! \return The volume-averaged temperature of the element
-  double temperature_at(int local_elem) const;
+  double temperature_at(int32_t local_elem) const;
 
   //! Return true if a local element is in the fluid region
   //! \param local_elem  A local element ID
   //! \return 1 if the local element is in fluid; 0 otherwise
-  int in_fluid_at(int local_elem) const;
+  int in_fluid_at(int32_t local_elem) const;
 
   //! Set the heat source for a given local element
   //!
@@ -95,24 +95,24 @@ public:
   //! \param local_elem A local element ID
   //! \param heat A heat source term
   //! \return Error code
-  int set_heat_source_at(int local_elem, double heat);
+  int set_heat_source_at(int32_t local_elem, double heat);
 
   //! Initialize the counts and displacements of local elements for each MPI Rank.
   void init_displs();
 
   std::string casename_; //!< Nek5000 casename (name of .rea file)
-  int lelg_;             //!< upper bound on number of mesh elements
-  int lelt_;             //!< upper bound on number of mesh elements per rank
-  int lx1_;              //!< polynomial order of the solution
-  int nelgt_;            //!< total number of mesh elements
-  int nelt_;             //!< number of local mesh elements
+  int32_t lelg_;             //!< upper bound on number of mesh elements
+  int32_t lelt_;             //!< upper bound on number of mesh elements per rank
+  int32_t lx1_;              //!< polynomial order of the solution
+  int32_t nelgt_;            //!< total number of mesh elements
+  int32_t nelt_;             //!< number of local mesh elements
 
   //! The number of local elements in each rank.
-  std::vector<int> local_displs_;
+  std::vector<int32_t> local_displs_;
 
   //! The displacements of local elements, relative to rank 0. Used in an MPI gatherv
   //! operation.
-  std::vector<int> local_counts_;
+  std::vector<int32_t> local_counts_;
 
   // Intended to be the local-to-global element ordering, as ensured by a Gatherv
   // operation. It is currently unused, as the coupling does not need to know the

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -129,7 +129,7 @@ private:
   //! cell instance index. The Nek global element indices refer to indices
   //! defined by the MPI_Gatherv operation, and do not reflect Nek's internal
   //! global element indexing.
-  std::unordered_map<int32_t, std::vector<int>> cell_to_elems_;
+  std::unordered_map<int32_t, std::vector<int32_t>> cell_to_elems_;
 
   //! Map that gives the OpenMC cell instance indices for a given Nek global
   //! element index. The Nek global element indices refer to indices defined by
@@ -142,11 +142,11 @@ private:
 
   //! Number of Nek local elements on this MPI rank.
   //! If nek_driver_ is active, this equals nek_driver.nelt_.  If not, it equals 0.
-  size_t n_local_elem_;
+  int32_t n_local_elem_;
 
   //! Number of Nek global elements across all ranks.
   //! Always equals nek_driver_.nelgt_.
-  size_t n_global_elem_;
+  int32_t n_global_elem_;
 };
 
 } // namespace enrico

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -53,10 +53,10 @@ void NekDriver::init_displs()
     local_counts_.resize(comm_.size);
     local_displs_.resize(comm_.size);
 
-    comm_.Allgather(&nelt_, 1, MPI_INT, local_counts_.data(), 1, MPI_INT);
+    comm_.Allgather(&nelt_, 1, MPI_INT32_T, local_counts_.data(), 1, MPI_INT32_T);
 
     local_displs_.at(0) = 0;
-    for (int i = 1; i < comm_.size; ++i) {
+    for (gsl::index i = 1; i < comm_.size; ++i) {
       local_displs_.at(i) = local_displs_.at(i - 1) + local_counts_.at(i - 1);
     }
   }
@@ -66,7 +66,7 @@ xt::xtensor<double, 1> NekDriver::temperature() const
 {
   // Each Nek proc finds the temperatures of its local elements
   double local_elem_temperatures[nelt_];
-  for (int i = 0; i < nelt_; ++i) {
+  for (gsl::index i = 0; i < nelt_; ++i) {
     local_elem_temperatures[i] = this->temperature_at(i + 1);
   }
 
@@ -93,7 +93,7 @@ xt::xtensor<double, 1> NekDriver::temperature() const
 xt::xtensor<int, 1> NekDriver::fluid_mask() const
 {
   int local_fluid_mask[nelt_];
-  for (int i = 0; i < nelt_; ++i) {
+  for (gsl::index i = 0; i < nelt_; ++i) {
     local_fluid_mask[i] = this->in_fluid_at(i + 1);
   }
 
@@ -117,7 +117,7 @@ xt::xtensor<double, 1> NekDriver::density() const
 {
   double local_densities[nelt_];
 
-  for (int i = 0; i < nelt_; ++i) {
+  for (gsl::index i = 0; i < nelt_; ++i) {
     if (this->in_fluid_at(i + 1) == 1) {
       auto T = this->temperature_at(i + 1);
       // nu1 returns specific volume in [m^3/kg]
@@ -150,7 +150,7 @@ void NekDriver::solve_step()
   C2F_nek_solve();
 }
 
-Position NekDriver::centroid_at(int local_elem) const
+Position NekDriver::centroid_at(int32_t local_elem) const
 {
   double x, y, z;
   err_chk(nek_get_local_elem_centroid(local_elem, &x, &y, &z),
@@ -158,7 +158,7 @@ Position NekDriver::centroid_at(int local_elem) const
   return {x, y, z};
 }
 
-double NekDriver::volume_at(int local_elem) const
+double NekDriver::volume_at(int32_t local_elem) const
 {
   double volume;
   err_chk(nek_get_local_elem_volume(local_elem, &volume),
@@ -166,7 +166,7 @@ double NekDriver::volume_at(int local_elem) const
   return volume;
 }
 
-double NekDriver::temperature_at(int local_elem) const
+double NekDriver::temperature_at(int32_t local_elem) const
 {
   double temperature;
   err_chk(nek_get_local_elem_temperature(local_elem, &temperature),
@@ -174,12 +174,12 @@ double NekDriver::temperature_at(int local_elem) const
   return temperature;
 }
 
-int NekDriver::in_fluid_at(int local_elem) const
+int NekDriver::in_fluid_at(int32_t local_elem) const
 {
   return nek_local_elem_is_in_fluid(local_elem);
 }
 
-int NekDriver::set_heat_source_at(int local_elem, double heat)
+int NekDriver::set_heat_source_at(int32_t local_elem, double heat)
 {
   return nek_set_heat_source(local_elem, heat);
 }

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -66,7 +66,7 @@ xt::xtensor<double, 1> NekDriver::temperature() const
 {
   // Each Nek proc finds the temperatures of its local elements
   double local_elem_temperatures[nelt_];
-  for (gsl::index i = 0; i < nelt_; ++i) {
+  for (int32_t i = 0; i < nelt_; ++i) {
     local_elem_temperatures[i] = this->temperature_at(i + 1);
   }
 
@@ -93,7 +93,7 @@ xt::xtensor<double, 1> NekDriver::temperature() const
 xt::xtensor<int, 1> NekDriver::fluid_mask() const
 {
   int local_fluid_mask[nelt_];
-  for (gsl::index i = 0; i < nelt_; ++i) {
+  for (int32_t i = 0; i < nelt_; ++i) {
     local_fluid_mask[i] = this->in_fluid_at(i + 1);
   }
 
@@ -117,7 +117,7 @@ xt::xtensor<double, 1> NekDriver::density() const
 {
   double local_densities[nelt_];
 
-  for (gsl::index i = 0; i < nelt_; ++i) {
+  for (int32_t i = 0; i < nelt_; ++i) {
     if (this->in_fluid_at(i + 1) == 1) {
       auto T = this->temperature_at(i + 1);
       // nu1 returns specific volume in [m^3/kg]

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -197,7 +197,7 @@ void OpenmcNekDriver::init_temperatures()
         const auto& global_elems = cell_to_elems_.at(i);
         const auto& c = openmc_driver_->cells_[i];
 
-        for (const auto &elem : global_elems) {
+        for (auto elem : global_elems) {
           double T = c.get_temperature();
           temperatures_[elem] = T;
           temperatures_prev_[elem] = T;

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -89,7 +89,7 @@ void OpenmcNekDriver::init_mappings()
 
   if (this->has_global_coupling_data()) {
     elem_centroids_.resize(n_global_elem_);
-    elem_fluid_mask_.resize({n_global_elem_});
+    elem_fluid_mask_.resize({gsl::narrow<std::size_t>(n_global_elem_)});
   }
 
   if (nek_driver_->active()) {
@@ -97,7 +97,7 @@ void OpenmcNekDriver::init_mappings()
     // Each Nek proc finds the centroids/fluid-identities of its local elements
     Position local_element_centroids[n_local_elem_];
     int local_element_is_in_fluid[n_local_elem_];
-    for (int i = 0; i < n_local_elem_; ++i) {
+    for (gsl::index i = 0; i < n_local_elem_; ++i) {
       local_element_centroids[i] = nek_driver_->centroid_at(i + 1);
       local_element_is_in_fluid[i] = nek_driver_->in_fluid_at(i + 1);
     }
@@ -132,7 +132,7 @@ void OpenmcNekDriver::init_mappings()
     if (openmc_driver_->active()) {
       std::unordered_map<CellInstance, gsl::index> cell_index;
 
-      for (int i = 0; i < n_global_elem_; ++i) {
+      for (gsl::index i = 0; i < n_global_elem_; ++i) {
         // Determine cell instance corresponding to global element
         Position elem_pos = elem_centroids_[i];
         CellInstance c{elem_pos};
@@ -197,7 +197,7 @@ void OpenmcNekDriver::init_temperatures()
         const auto& global_elems = cell_to_elems_.at(i);
         const auto& c = openmc_driver_->cells_[i];
 
-        for (int elem : global_elems) {
+        for (const auto &elem : global_elems) {
           double T = c.get_temperature();
           temperatures_[elem] = T;
           temperatures_prev_[elem] = T;
@@ -228,7 +228,7 @@ void OpenmcNekDriver::init_volumes()
   if (nek_driver_->active()) {
     // Every Nek proc gets its local element volumes (lev)
     double local_elem_volumes[n_local_elem_];
-    for (int i = 0; i < n_local_elem_; ++i) {
+    for (gsl::index i = 0; i < n_local_elem_; ++i) {
       local_elem_volumes[i] = nek_driver_->volume_at(i + 1);
     }
     // Gather all the local element volumes on the Nek5000/OpenMC root
@@ -368,12 +368,12 @@ void OpenmcNekDriver::set_heat_source()
 
   if (nek_driver_->active()) {
     // Determine displacement for this rank
-    int displacement = nek_driver_->local_displs_[nek_driver_->comm_.rank];
+    auto displacement = nek_driver_->local_displs_[nek_driver_->comm_.rank];
 
     // Loop over local elements to set heat source
-    for (int local_elem = 1; local_elem <= n_local_elem_; ++local_elem) {
+    for (gsl::index local_elem = 1; local_elem <= n_local_elem_; ++local_elem) {
       // get corresponding global element
-      int global_index = local_elem + displacement - 1;
+      gsl::index global_index = local_elem + displacement - 1;
 
       // get index to cell instance
       int32_t cell_index = elem_to_cell_.at(global_index);
@@ -442,7 +442,7 @@ void OpenmcNekDriver::update_density()
       // For each OpenMC cell instance in a fluid cell, volume average the
       // densities and set
       // TODO:  Might be able to use xtensor masking to do some of this
-      for (int i = 0; i < openmc_driver_->cells_.size(); ++i) {
+      for (gsl::index i = 0; i < openmc_driver_->cells_.size(); ++i) {
         if (cell_fluid_mask_[i] == 1) {
           auto& c = openmc_driver_->cells_[i];
           double average_density = 0.0;


### PR DESCRIPTION
This is a second pass at #54.  The changes can be summarized as follows:
* The Nek interface (C and Fortran) has been updated to use `int32_t` for indices.  The submodule has been updated accordingly.  
* In ENRICO, loop indices that are used to index Nek arrays are declared as `int32_t`.  `gsl::index` isn't really appropriate here, since the Nek arrays can only be as long as an int32.  
* Loop indices that are used to index `std::vector` and xtensors are declared as `gsl::index`