### PR TITLE
Make fluid_mask optional and leave interpretation of density to the solver

### DIFF
--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -24,13 +24,11 @@ public:
   //! \return Temperature in each region as [K]
   virtual xt::xtensor<double, 1> temperature() const = 0;
 
-  //! Get the density in each region
+  //! Get the density in each region. The interpretation of this density,
+  //! i.e. whether it refers to fluid elements or both fluid and solid
+  //! elements, is to the discretion of the particular driver.
   //! \return Temperature in each region as [g/cm^3]
   virtual xt::xtensor<double, 1> density() const = 0;
-
-  //! States whether each region is in fluid
-  //! \return For each region, 1 if region is in fluid and 0 otherwise
-  virtual xt::xtensor<int, 1> fluid_mask() const = 0;
 
   double pressure_bc_; //! System pressure in [MPa]
 };

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -52,7 +52,9 @@ public:
 
   xt::xtensor<double, 1> density() const final;
 
-  xt::xtensor<int, 1> fluid_mask() const final;
+  //! States whether each region is in fluid
+  //! \return For each region, 1 if region is in fluid and 0 otherwise
+  xt::xtensor<int, 1> fluid_mask() const;
 
   //! Get the coordinate of a local element's centroid.
   //!

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -215,9 +215,9 @@ public:
 
   xt::xtensor<double, 1> temperature() const final;
 
+  //! The surrogate heat driver does not compute solid density, so this method
+  //! only returns the fluid density.
   xt::xtensor<double, 1> density() const final;
-
-  xt::xtensor<int, 1> fluid_mask() const final;
 
   //! Returns solid temperature in [K] for given region
   double solid_temperature(std::size_t pin, std::size_t axial, std::size_t ring) const;

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -205,22 +205,20 @@ void OpenmcHeatDriver::init_densities()
       // the density IC based on the densities used in the OpenMC input file.
 
       int fluid_index = 0;
-      for (gsl::index i = 0; i < heat_driver_->n_pins_; ++i) {
-        for (gsl::index j = 0; j < heat_driver_->n_axial_; ++j) {
+      int n_fluid_elems = heat_driver_->n_pins_ * heat_driver_->n_axial_;
+      for (gsl::index fluid_index = 0; fluid_index < n_fluid_elems; ++fluid_index) {
+        double mass = 0.0;
+        double total_vol = 0.0;
 
-          double mass = 0.0;
-          double total_vol = 0.0;
+        for (const auto& idx : elem_to_cell_inst_[fluid_index]) {
+          const auto& c = openmc_driver_->cells_[idx];
+          double vol = c.volume_;
 
-          for (const auto& idx : elem_to_cell_inst_[fluid_index++]) {
-            const auto& c = openmc_driver_->cells_[idx];
-            double vol = c.volume_;
-
-            total_vol += vol;
-            mass += c.get_density() * vol;
-          }
-
-          densities_(fluid_index) = mass / total_vol;
+          total_vol += vol;
+          mass += c.get_density() * vol;
         }
+
+        densities_(fluid_index) = mass / total_vol;
       }
 
       std::copy(densities_.begin(), densities_.end(), densities_prev_.begin());

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -200,10 +200,6 @@ void SurrogateHeatDriver::generate_arrays()
   // Create empty arrays for temperature and density in the fluid phase
   fluid_temperature_ = xt::empty<double>({n_pins_, n_axial_});
   fluid_density_ = xt::empty<double>({n_pins_, n_axial_});
-
-  xt::xtensor<int, 1> s_mask({n_pins_ * n_axial_ * n_rings()}, 0);
-  xt::xtensor<int, 1> f_mask({n_pins_ * n_axial_}, 1);
-  fluid_mask_ = xt::concatenate(xt::xtuple(s_mask, f_mask), 0);
 }
 
 double SurrogateHeatDriver::rod_axial_node_power(const int pin, const int axial) const
@@ -446,14 +442,7 @@ double SurrogateHeatDriver::solid_temperature(std::size_t pin, std::size_t axial
 
 xt::xtensor<double, 1> SurrogateHeatDriver::density() const
 {
-  xt::xarray<double> rhos({n_pins_ * n_axial_ * n_rings()}, 0.0);
-  xt::xarray<double> rhof = {xt::flatten(fluid_density_)};
-  return xt::concatenate(xt::xtuple(rhos, rhof), 0);
-}
-
-xt::xtensor<int, 1> SurrogateHeatDriver::fluid_mask() const
-{
-  return fluid_mask_;
+  return xt::flatten(fluid_density_);
 }
 
 void SurrogateHeatDriver::write_step(int timestep, int iteration)


### PR DESCRIPTION
Not all T/H drivers compute solid density, so it is not always necessary to compute a `fluid_mask` to pick out the fluid entries in the density solution. This PR changes the `fluid_mask` to be a member of `NekDriver` instead of the base T/H driver class.