### PR TITLE
Updates to patch_singlerod_rea.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ SESSION.NAME
 compile_commands.json
 *.fld*
 doc/build/
+*.rej

--- a/ci/patch_singlerod_rea.sh
+++ b/ci/patch_singlerod_rea.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
-if [ "$MODE" = "openmc_nek5000" ]; then
+if [[ -z "$MODE" ]] || [[ "$MODE" == "openmc_nek5000" ]] ; then
   cd tests/singlerod/short
   patch -N rodcht.rea ci_config/rodcht_rea.diff || true
   patch -N SIZE ci_config/SIZE.diff || true


### PR DESCRIPTION
I use `ci/patch_singlerod_rea.sh` pretty often when I'm developing locally.  It was written for a CI build matrix, and it ran `patch` only if the env variable `$MODE` equaled `openmc_nek5000`.  I changed it so it also runs `patch` if `$MODE` is undefined, which is more convenient when you run it manually.  Shouldn't ruin the CI build matrix, since `$MODE` is always set to something there.  