### PR TITLE
Density relaxation

### DIFF
--- a/doc/source/input.rst
+++ b/doc/source/input.rst
@@ -49,7 +49,7 @@ reached if
 -----------
 
 Underrelaxation parameter used on a heat source update. Let :math:`q_i` be the
-heat source at iteration :math:`i` and :math:`\tilde{q}_{i+1}` be next estimate of
+heat source at iteration :math:`i` and :math:`\tilde{q}_{i+1}` be the next estimate of
 the heat source as determined by the neutronics solver. Then, the heat source
 for iteration :math:`i + 1` is:
 
@@ -64,14 +64,29 @@ Choosing :math:`\alpha = 1` corresponds to no underrelaxation.
 -------------
 
 Underrelaxation parameter used on a temperature update. Let :math:`T_i` be the
-temperature at iteration :math:`i` and :math:`\tilde{T}_{i+1}` be next estimate
-of the temperature as determined by the neutronics solver. Then, the temperature
+temperature at iteration :math:`i` and :math:`\tilde{T}_{i+1}` be the next estimate
+of the temperature as determined by the thermal-fluids solver. Then, the temperature
 for iteration :math:`i + 1` is:
 
 .. math::
     T_{i+1} = (1 - \alpha_T) T_i + \alpha_T \tilde{T}_{i+1}
 
 Choosing :math:`\alpha_T = 1` corresponds to no underrelaxation.
+
+*Default*: The same value chosen for ``<alpha>``
+
+``<alpha_rho>``
+-------------
+
+Underrelaxation parameter used on a density update update. Let :math:`\rho_i` be the
+density at iteration :math:`i` and :math:`\tilde{\rho}_{i+1}` be the next estimate
+of the density as determined by the thermal-fluids solver. Then, the density
+for iteration :math:`i + 1` is:
+
+.. math::
+    \rho_{i+1} = (1 - \alpha_\rho) \rho_i + \alpha_\rho \tilde{\rho}_{i+1}
+
+Choosing :math:`\alpha_\rho = 1` corresponds to no underrelaxation.
 
 *Default*: The same value chosen for ``<alpha>``
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -105,6 +105,10 @@ public:
   //! relaxation aplied to the heat source if not set
   double alpha_T_{alpha_};
 
+  //! Constant relaxation factor for the density, defaults to the
+  //! relaxation applied to the heat source if not set
+  double alpha_rho_{alpha_};
+
   //! Enumeration of available temperature initial condition specifications.
   //! 'neutronics' sets temperature condition from the neutronics input files,
   //! while 'heat' sets temperature based on a thermal-fluids input (or restart) file.

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -48,7 +48,10 @@ public:
   virtual void set_temperature() {};
 
   //! Update the density for the neutronics solver
-  virtual void update_density() {}
+  void update_density();
+
+  //! Update the density for the neutronics solver
+  virtual void set_density() {}
 
   //! Check convergence of the coupled solve for the current Picard iteration.
   virtual bool is_converged();

--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -34,7 +34,7 @@ public:
 
   void set_temperature() override;
 
-  void update_density() override;
+  void set_density() override;
 
   NeutronicsDriver& get_neutronics_driver() const override;
 

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -42,7 +42,7 @@ public:
 
   void set_temperature() override;
 
-  void update_density() override;
+  void set_density() override;
 
   NeutronicsDriver& get_neutronics_driver() const override;
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -194,4 +194,24 @@ void CoupledDriver::update_temperature()
   set_temperature();
 }
 
+void CoupledDriver::update_density()
+{
+  // Store previous density solution; a previous solution will always be present
+  // because a density IC is set and the neutronics solver runs first
+  if (has_global_coupling_data()) {
+    std::copy(densities_.begin(), densities_.end(), densities_prev_.begin());
+  }
+
+  auto& heat = get_heat_driver();
+  if (heat.active()) {
+    auto d = heat.density();
+
+    if (heat.has_coupling_data())
+      densities_ = d;
+  }
+
+  // Set density in the neutronics solver
+  set_density();
+}
+
 } // namespace enrico

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -25,6 +25,9 @@ CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
   if (node.child("alpha_T"))
     alpha_T_ = node.child("alpha_T").text().as_double();
 
+  if (node.child("alpha_rho"))
+    alpha_rho_ = node.child("alpha_rho").text().as_double();
+
   if (node.child("temperature_ic")) {
     auto s = std::string{node.child_value("temperature_ic")};
 
@@ -54,6 +57,8 @@ CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
   Expects(max_picard_iter_ >= 0);
   Expects(epsilon_ > 0);
   Expects(alpha_ > 0);
+  Expects(alpha_T_ > 0);
+  Expects(alpha_rho_ > 0);
 }
 
 void CoupledDriver::execute()
@@ -207,7 +212,7 @@ void CoupledDriver::update_density()
     auto d = heat.density();
 
     if (heat.has_coupling_data())
-      densities_ = d;
+      densities_ = alpha_rho_ * d + (1.0 - alpha_rho_) * densities_prev_;
   }
 
   // Set density in the neutronics solver

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -339,14 +339,8 @@ void OpenmcHeatDriver::set_heat_source()
   }
 }
 
-void OpenmcHeatDriver::update_density()
+void OpenmcHeatDriver::set_density()
 {
-  if (this->has_global_coupling_data()) {
-    std::copy(densities_.begin(), densities_.end(), densities_prev_.begin());
-  }
-
-  densities_ = heat_driver_->density();
-
   for (gsl::index i = n_solid_cells_; i < n_solid_cells_ + n_fluid_cells_; ++i) {
     const auto& c = openmc_driver_->cells_[i];
     const auto& elems = cell_inst_to_elem_[i];

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -416,21 +416,9 @@ void OpenmcNekDriver::set_temperature()
   }
 }
 
-void OpenmcNekDriver::update_density()
+void OpenmcNekDriver::set_density()
 {
-  if (this->has_global_coupling_data()) {
-    std::copy(densities_.begin(), densities_.end(), densities_prev_.begin());
-  }
-
   if (nek_driver_->active()) {
-    // On Nek's master rank, d gets global data. On Nek's other ranks, d is empty.
-    auto d = nek_driver_->density();
-
-    // Update elem_densities_ on Nek's master rank only.
-    if (nek_driver_->has_coupling_data()) {
-      densities_ = d;
-    }
-
     // Since OpenMC's and Nek's master ranks are the same, we know that elem_densities_ on
     // OpenMC's master rank were updated.  Now we broadcast to the other OpenMC ranks.
     // TODO: This won't work if the Nek/OpenMC communicators are disjoint


### PR DESCRIPTION
This MR applies relaxation to the density field, so now the interface for updating and setting coupled fields is uniform across the heat source, temperatures, and densities.