### PR TITLE
Factor out common communication pattern in OpenmcNekDriver

### DIFF
--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -43,6 +43,7 @@ public:
   virtual std::size_t n_global_elem() const { return 0; }
 
   std::vector<Position> centroids() const;
+  std::vector<double> volumes() const;
 
   template<typename T>
   std::vector<T> gather(const std::vector<T>& local_field) const;
@@ -68,6 +69,7 @@ private:
   virtual std::vector<double> density_local() const { return {}; }
   virtual std::vector<int> fluid_mask_local() const { return {}; }
   virtual std::vector<Position> centroid_local() const { return {}; }
+  virtual std::vector<double> volume_local() const { return {}; }
 };
 
 template<typename T>

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -34,11 +34,11 @@ public:
   virtual xt::xtensor<double, 1> density() const = 0;
 
   //! Get the number of local mesh elements
-  // TODO: make pure virtual
+  // TODO: make pure virtual and remove implementation
   virtual int n_local_elem() const { return 0; }
 
   //! Get the number of global mesh elements
-  // TODO: make pure virtual
+  // TODO: make pure virtual and remove implementation
   virtual std::size_t n_global_elem() const { return 0; }
 
   template<typename T>
@@ -58,6 +58,12 @@ public:
 protected:
   //! Initialize the counts and displacements of local elements for each MPI Rank.
   void init_displs();
+
+private:
+  // TODO: Make pure virtual and remove implementation
+  virtual std::vector<double> temperature_local() const { return {}; }
+  virtual std::vector<double> density_local() const { return {}; }
+  virtual std::vector<int> fluid_mask_local() const { return {}; }
 };
 
 template<typename T>

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -4,6 +4,7 @@
 #define HEAT_FLUIDS_DRIVER_H
 
 #include "enrico/driver.h"
+#include "enrico/geom.h"
 #include "enrico/message_passing.h"
 #include "xtensor/xtensor.hpp"
 
@@ -41,6 +42,8 @@ public:
   // TODO: make pure virtual and remove implementation
   virtual std::size_t n_global_elem() const { return 0; }
 
+  std::vector<Position> centroids() const;
+
   template<typename T>
   std::vector<T> gather(const std::vector<T>& local_field) const;
 
@@ -64,6 +67,7 @@ private:
   virtual std::vector<double> temperature_local() const { return {}; }
   virtual std::vector<double> density_local() const { return {}; }
   virtual std::vector<int> fluid_mask_local() const { return {}; }
+  virtual std::vector<Position> centroid_local() const { return {}; }
 };
 
 template<typename T>

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -26,13 +26,19 @@ public:
 
   //! Get the temperature in each region
   //! \return Temperature in each region as [K]
-  virtual xt::xtensor<double, 1> temperature() const = 0;
+  // TODO: Remove virtual
+  virtual xt::xtensor<double, 1> temperature() const;
 
   //! Get the density in each region. The interpretation of this density,
   //! i.e. whether it refers to fluid elements or both fluid and solid
   //! elements, is to the discretion of the particular driver.
   //! \return Density in each region as [g/cm^3]
-  virtual xt::xtensor<double, 1> density() const = 0;
+  // TODO: Remove virtual
+  virtual xt::xtensor<double, 1> density() const;
+
+  //! States whether each region is in fluid
+  //! \return For each region, 1 if region is in fluid and 0 otherwise
+  xt::xtensor<int, 1> fluid_mask() const;
 
   //! Get the number of local mesh elements
   //! \return Number of local mesh elements

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -38,7 +38,7 @@ public:
 
   //! States whether each region is in fluid
   //! \return For each region, 1 if region is in fluid and 0 otherwise
-  xt::xtensor<int, 1> fluid_mask() const;
+  std::vector<int> fluid_mask() const;
 
   //! Get the number of local mesh elements
   //! \return Number of local mesh elements
@@ -108,8 +108,11 @@ std::vector<T> HeatFluidsDriver::gather(const std::vector<T>& local_field) const
   std::vector<T> global_field;
 
   if (this->active()) {
+    if (this->has_coupling_data()) {
+      global_field.resize(this->n_global_elem());
+    }
+
     // Gather all the local quantities on to the root process
-    global_field.resize(this->n_global_elem());
     comm_.Gatherv(local_field.data(),
                   local_field.size(),
                   get_mpi_type<T>(),

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -58,11 +58,6 @@ public:
   //! \return Vector of all volumes
   std::vector<double> volumes() const;
 
-  //! Gather local distributed field into global field (on rank 0)
-  //! \return Global field collected from all ranks
-  template<typename T>
-  std::vector<T> gather(const std::vector<T>& local_field) const;
-
   double pressure_bc_; //! System pressure in [MPa]
 
   //! The displacements of local elements, relative to rank 0. Used in an MPI
@@ -79,6 +74,11 @@ protected:
   void init_displs();
 
 private:
+  //! Gather local distributed field into global field (on rank 0)
+  //! \return Global field collected from all ranks
+  template<typename T>
+  std::vector<T> gather(const std::vector<T>& local_field) const;
+
   // TODO: Make methods below pure virtual and remove implementation
 
   //! Get temperature of local mesh elements

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -41,6 +41,19 @@ public:
   virtual std::size_t n_global_elem() const { return 0; }
 
   double pressure_bc_; //! System pressure in [MPa]
+
+  //! The displacements of local elements, relative to rank 0. Used in an MPI
+  //! Gatherv operation.
+  // TODO: Move to private
+  std::vector<int32_t> local_displs_;
+
+  //! The number of local elements in each rank.
+  // TODO: Move to private
+  std::vector<int32_t> local_counts_;
+
+protected:
+  //! Initialize the counts and displacements of local elements for each MPI Rank.
+  void init_displs();
 };
 
 } // namespace enrico

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -31,20 +31,29 @@ public:
   //! Get the density in each region. The interpretation of this density,
   //! i.e. whether it refers to fluid elements or both fluid and solid
   //! elements, is to the discretion of the particular driver.
-  //! \return Temperature in each region as [g/cm^3]
+  //! \return Density in each region as [g/cm^3]
   virtual xt::xtensor<double, 1> density() const = 0;
 
   //! Get the number of local mesh elements
+  //! \return Number of local mesh elements
   // TODO: make pure virtual and remove implementation
   virtual int n_local_elem() const { return 0; }
 
   //! Get the number of global mesh elements
+  //! \return Number of global mesh elements
   // TODO: make pure virtual and remove implementation
   virtual std::size_t n_global_elem() const { return 0; }
 
+  //! Get the centroids of all mesh elements
+  //! \return Vector of all centroids
   std::vector<Position> centroids() const;
+
+  //! Get the volumes of all mesh elements
+  //! \return Vector of all volumes
   std::vector<double> volumes() const;
 
+  //! Gather local distributed field into global field (on rank 0)
+  //! \return Global field collected from all ranks
   template<typename T>
   std::vector<T> gather(const std::vector<T>& local_field) const;
 
@@ -64,11 +73,26 @@ protected:
   void init_displs();
 
 private:
-  // TODO: Make pure virtual and remove implementation
+  // TODO: Make methods below pure virtual and remove implementation
+
+  //! Get temperature of local mesh elements
+  //! \return Temperature on local mesh elements in [K]
   virtual std::vector<double> temperature_local() const { return {}; }
+
+  //! Get density of local mesh elements
+  //! \return Density on local mesh elements in [g/cm^3]
   virtual std::vector<double> density_local() const { return {}; }
+
+  //! States whether each local region is in fluid
+  //! \return For each local region, 1 if region is in fluid and 0 otherwise
   virtual std::vector<int> fluid_mask_local() const { return {}; }
+
+  //! Get centroids on local mesh elements
+  //! \return Centroids on local mesh elements
   virtual std::vector<Position> centroid_local() const { return {}; }
+
+  //! Get volumes on local mesh elements
+  //! \return Volumes on local mesh elements
   virtual std::vector<double> volume_local() const { return {}; }
 };
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -6,6 +6,8 @@
 #include "enrico/driver.h"
 #include "xtensor/xtensor.hpp"
 
+#include <cstddef> // for size_t
+
 namespace enrico {
 
 //! Base class for driver that controls a heat-fluids solve
@@ -29,6 +31,14 @@ public:
   //! elements, is to the discretion of the particular driver.
   //! \return Temperature in each region as [g/cm^3]
   virtual xt::xtensor<double, 1> density() const = 0;
+
+  //! Get the number of local mesh elements
+  // TODO: make pure virtual
+  virtual int n_local_elem() const { return 0; }
+
+  //! Get the number of global mesh elements
+  // TODO: make pure virtual
+  virtual std::size_t n_global_elem() const { return 0; }
 
   double pressure_bc_; //! System pressure in [MPa]
 };

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -42,7 +42,7 @@ public:
   virtual std::size_t n_global_elem() const { return 0; }
 
   template<typename T>
-  std::vector<T> gather(const std::vector<T>& local_field);
+  std::vector<T> gather(const std::vector<T>& local_field) const;
 
   double pressure_bc_; //! System pressure in [MPa]
 
@@ -61,7 +61,7 @@ protected:
 };
 
 template<typename T>
-std::vector<T> HeatFluidsDriver::gather(const std::vector<T>& local_field)
+std::vector<T> HeatFluidsDriver::gather(const std::vector<T>& local_field) const
 {
   std::vector<T> global_field;
 

--- a/include/enrico/message_passing.h
+++ b/include/enrico/message_passing.h
@@ -3,11 +3,21 @@
 #ifndef ENRICO_MESSAGE_PASSING_H
 #define ENRICO_MESSAGE_PASSING_H
 
-#include "mpi.h"
 #include "geom.h"
+#include "mpi.h"
 
 //! The ENRICO namespace
 namespace enrico {
+
+//==============================================================================
+// Global variables
+//==============================================================================
+
+extern MPI_Datatype position_mpi_datatype;
+
+//==============================================================================
+// Functions
+//==============================================================================
 
 //! Splits a given MPI comunicator into new inter- and intra-node communicators
 //!
@@ -44,9 +54,18 @@ void get_node_comms(MPI_Comm super_comm,
                     MPI_Comm* sub_comm,
                     MPI_Comm* intranode_comm);
 
-//! Define position MPI data type
-//! \return MPI position data type
-MPI_Datatype define_position_mpi_datatype();
+//! Create MPI datatype for Position struct
+void init_mpi_datatypes();
+
+//! Free any MPI datatypes
+void free_mpi_datatypes();
+
+//! Map types to corresponding MPI datatypes
+template<typename T>
+MPI_Datatype get_mpi_type()
+{
+  return MPI_DATATYPE_NULL;
+}
 
 } // namespace enrico
 

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -103,11 +103,8 @@ public:
   void init_displs();
 
   std::string casename_; //!< Nek5000 casename (name of .rea file)
-  int32_t lelg_;             //!< upper bound on number of mesh elements
-  int32_t lelt_;             //!< upper bound on number of mesh elements per rank
-  int32_t lx1_;              //!< polynomial order of the solution
-  int32_t nelgt_;            //!< total number of mesh elements
-  int32_t nelt_;             //!< number of local mesh elements
+  int32_t nelgt_;        //!< total number of mesh elements
+  int32_t nelt_;         //!< number of local mesh elements
 
   //! The number of local elements in each rank.
   std::vector<int32_t> local_displs_;

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -48,18 +48,6 @@ public:
   //! Only Nek's master rank has access to the global data; data on other ranks is empty
   bool has_coupling_data() const final { return comm_.rank == 0; }
 
-  //! Get the temperature in each region
-  //! \return Temperature in each region as [K]
-  xt::xtensor<double, 1> temperature() const final;
-
-  //! Get the density in each region
-  //! \return Density in each region as [g/cm^3]
-  xt::xtensor<double, 1> density() const final;
-
-  //! States whether each region is in fluid
-  //! \return For each region, 1 if region is in fluid and 0 otherwise
-  xt::xtensor<int, 1> fluid_mask() const;
-
   //! Get the coordinate of a local element's centroid.
   //!
   //! The coordinate is dimensionless.  Its units depend on the unit system used that was

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -113,6 +113,7 @@ private:
   std::vector<double> density_local() const override;
   std::vector<int> fluid_mask_local() const override;
   std::vector<Position> centroid_local() const override;
+  std::vector<double> volume_local() const override;
 
   int32_t nelgt_; //!< total number of mesh elements
   int32_t nelt_;  //!< number of local mesh elements

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -102,17 +102,7 @@ public:
   int n_local_elem() const override { return active() ? nelt_ : 0; }
   std::size_t n_global_elem() const override { return active() ? nelgt_ : 0; }
 
-  //! Initialize the counts and displacements of local elements for each MPI Rank.
-  void init_displs();
-
   std::string casename_; //!< Nek5000 casename (name of .rea file)
-
-  //! The displacements of local elements, relative to rank 0. Used in an MPI
-  //! Gatherv operation.
-  std::vector<int32_t> local_displs_;
-
-  //! The number of local elements in each rank.
-  std::vector<int32_t> local_counts_;
 
   // Intended to be the local-to-global element ordering, as ensured by a Gatherv
   // operation. It is currently unused, as the coupling does not need to know the

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -109,6 +109,10 @@ public:
   // local-global ordering.
   // std::vector<int> local_ordering_;
 private:
+  std::vector<double> temperature_local() const override;
+  std::vector<double> density_local() const override;
+  std::vector<int> fluid_mask_local() const override;
+
   int32_t nelgt_; //!< total number of mesh elements
   int32_t nelt_;  //!< number of local mesh elements
 };

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -99,24 +99,28 @@ public:
   //! \return Error code
   int set_heat_source_at(int32_t local_elem, double heat);
 
+  int n_local_elem() const override { return active() ? nelt_ : 0; }
+  std::size_t n_global_elem() const override { return active() ? nelgt_ : 0; }
+
   //! Initialize the counts and displacements of local elements for each MPI Rank.
   void init_displs();
 
   std::string casename_; //!< Nek5000 casename (name of .rea file)
-  int32_t nelgt_;        //!< total number of mesh elements
-  int32_t nelt_;         //!< number of local mesh elements
 
-  //! The number of local elements in each rank.
+  //! The displacements of local elements, relative to rank 0. Used in an MPI
+  //! Gatherv operation.
   std::vector<int32_t> local_displs_;
 
-  //! The displacements of local elements, relative to rank 0. Used in an MPI gatherv
-  //! operation.
+  //! The number of local elements in each rank.
   std::vector<int32_t> local_counts_;
 
   // Intended to be the local-to-global element ordering, as ensured by a Gatherv
   // operation. It is currently unused, as the coupling does not need to know the
   // local-global ordering.
   // std::vector<int> local_ordering_;
+private:
+  int32_t nelgt_; //!< total number of mesh elements
+  int32_t nelt_;  //!< number of local mesh elements
 };
 
 } // namespace enrico

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -48,8 +48,12 @@ public:
   //! Only Nek's master rank has access to the global data; data on other ranks is empty
   bool has_coupling_data() const final { return comm_.rank == 0; }
 
+  //! Get the temperature in each region
+  //! \return Temperature in each region as [K]
   xt::xtensor<double, 1> temperature() const final;
 
+  //! Get the density in each region
+  //! \return Density in each region as [g/cm^3]
   xt::xtensor<double, 1> density() const final;
 
   //! States whether each region is in fluid
@@ -99,7 +103,12 @@ public:
   //! \return Error code
   int set_heat_source_at(int32_t local_elem, double heat);
 
+  //! Get the number of local mesh elements
+  //! \return Number of local mesh elements
   int n_local_elem() const override { return active() ? nelt_ : 0; }
+
+  //! Get the number of global mesh elements
+  //! \return Number of global mesh elements
   std::size_t n_global_elem() const override { return active() ? nelgt_ : 0; }
 
   std::string casename_; //!< Nek5000 casename (name of .rea file)
@@ -109,10 +118,24 @@ public:
   // local-global ordering.
   // std::vector<int> local_ordering_;
 private:
+  //! Get temperature of local mesh elements
+  //! \return Temperature on local mesh elements in [K]
   std::vector<double> temperature_local() const override;
+
+  //! Get density of local mesh elements
+  //! \return Density on local mesh elements in [g/cm^3]
   std::vector<double> density_local() const override;
+
+  //! States whether each local region is in fluid
+  //! \return For each local region, 1 if region is in fluid and 0 otherwise
   std::vector<int> fluid_mask_local() const override;
+
+  //! Get centroids on local mesh elements
+  //! \return Centroids on local mesh elements
   std::vector<Position> centroid_local() const override;
+
+  //! Get volumes on local mesh elements
+  //! \return Volumes on local mesh elements
   std::vector<double> volume_local() const override;
 
   int32_t nelgt_; //!< total number of mesh elements

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -112,6 +112,7 @@ private:
   std::vector<double> temperature_local() const override;
   std::vector<double> density_local() const override;
   std::vector<int> fluid_mask_local() const override;
+  std::vector<Position> centroid_local() const override;
 
   int32_t nelgt_; //!< total number of mesh elements
   int32_t nelt_;  //!< number of local mesh elements

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -3,7 +3,9 @@
 #ifndef NEUTRONICS_DRIVER_H
 #define NEUTRONICS_DRIVER_H
 
-#include "driver.h"
+#include "enrico/driver.h"
+#include "enrico/message_passing.h"
+
 #include "xtensor/xtensor.hpp"
 
 namespace enrico {
@@ -21,7 +23,27 @@ public:
   //! \param power User-specified power in [W]
   //! \return Heat source in each material as [W/cm3]
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
+
+  //! Broadcast data across ranks, possibly resizing vector
+  //! \param values Values to broadcast (significant at rank 0)
+  template<typename T>
+  void broadcast(std::vector<T>& values) const;
 };
+
+template<typename T>
+void NeutronicsDriver::broadcast(std::vector<T>& values) const
+{
+  if (this->active()) {
+    // First broadcast the size of the vector
+    int n = values.size();
+    comm_.Bcast(&n, 1, MPI_INT);
+
+    // Resize vector (for rank != 0) and broacast data
+    if (values.size() != n)
+      values.resize(n);
+    comm_.Bcast(values.data(), n, get_mpi_type<T>());
+  }
+}
 
 } // namespace enrico
 

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -23,27 +23,7 @@ public:
   //! \param power User-specified power in [W]
   //! \return Heat source in each material as [W/cm3]
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
-
-  //! Broadcast data across ranks, possibly resizing vector
-  //! \param values Values to broadcast (significant at rank 0)
-  template<typename T>
-  void broadcast(std::vector<T>& values) const;
 };
-
-template<typename T>
-void NeutronicsDriver::broadcast(std::vector<T>& values) const
-{
-  if (this->active()) {
-    // First broadcast the size of the vector
-    int n = values.size();
-    comm_.Bcast(&n, 1, MPI_INT);
-
-    // Resize vector (for rank != 0) and broacast data
-    if (values.size() != n)
-      values.resize(n);
-    comm_.Bcast(values.data(), n, get_mpi_type<T>());
-  }
-}
 
 } // namespace enrico
 

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -27,9 +27,6 @@ public:
   //! \param node XML node containing settings
   explicit OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node);
 
-  //! Frees any data structures that need manual freeing.
-  ~OpenmcNekDriver();
-
   //! Whether the calling rank has access to global coupling fields. Because the OpenMC
   //! and Nek communicators are assumed to overlap (though they are not the same), and
   //! Nek broadcasts its solution onto the OpenMC ranks, we need to check that both

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -106,7 +106,7 @@ private:
   //! States whether a global element is in the fluid region
   //! These are **not** ordered by Nek's global element indices.  Rather, these are
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
-  xt::xtensor<int, 1> elem_fluid_mask_;
+  std::vector<int> elem_fluid_mask_;
 
   //! States whether an OpenMC cell in the fluid region
   xt::xtensor<int, 1> cell_fluid_mask_;

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -85,9 +85,6 @@ protected:
   void init_cell_fluid_mask();
 
 private:
-  //! Initialize MPI datatypes (currently, only position_mpi_datatype)
-  void init_mpi_datatypes();
-
   //! Create bidirectional mappings from OpenMC cell instances to/from Nek5000 elements
   void init_mappings();
 
@@ -97,15 +94,9 @@ private:
   //! Initialize global volume buffers for OpenMC ranks
   void init_volumes();
 
-  //! Frees the MPI datatypes (currently, only position_mpi_datatype)
-  void free_mpi_datatypes();
-
   std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
 
   std::unique_ptr<NekDriver> nek_driver_; //!< The Nek5000 driver
-
-  //! MPI datatype for sending/receiving Position objects.
-  MPI_Datatype position_mpi_datatype;
 
   //! Gives a Position of a global element's centroid
   //! These are **not** ordered by Nek's global element indices.  Rather, these are

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -114,7 +114,7 @@ private:
   //! The dimensionless volumes of Nek's global elements
   //! These are **not** ordered by Nek's global element indices.  Rather, these are
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
-  xt::xtensor<double, 1> elem_volumes_;
+  std::vector<double> elem_volumes_;
 
   //! Map that gives a list of Nek element global indices for a given OpenMC
   //! cell instance index. The Nek global element indices refer to indices

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -130,14 +130,6 @@ private:
 
   //! Number of cell instances in OpenMC model
   int32_t n_cells_;
-
-  //! Number of Nek local elements on this MPI rank.
-  //! If nek_driver_ is active, this equals nek_driver.nelt_.  If not, it equals 0.
-  int32_t n_local_elem_;
-
-  //! Number of Nek global elements across all ranks.
-  //! Always equals nek_driver_.nelgt_.
-  int32_t n_global_elem_;
 };
 
 } // namespace enrico

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -7,12 +7,12 @@
 #include "Nemesis/comm/global.hh"
 
 #include "Assembly_Model.h"
-#include "shift_driver.h"
 #include "enrico/error.h"
 #include "enrico/message_passing.h"
 #include "enrico/nek_driver.h"
-#include "smrt_coupled_driver.h"
 #include "nek5000/core/nek_interface.h"
+#include "shift_driver.h"
+#include "smrt_coupled_driver.h"
 
 namespace enrico {
 //===========================================================================//
@@ -47,9 +47,6 @@ private:
   int d_th_num_local;
   int d_th_num_global;
 
-  // MPI datatype for Position objects
-  MPI_Datatype d_position_mpi_type;
-
   // Field data
   std::vector<double> d_temperatures;
   std::vector<double> d_densities;
@@ -57,7 +54,6 @@ private:
 
   // Power indexed by shift cell ID
   std::vector<double> d_power_shift;
-
 
 public:
   // Constructor
@@ -74,19 +70,6 @@ public:
   void solve();
 
 private:
-  // Map "standard" types to corresponding MPI types
-  template<typename T>
-  MPI_Datatype get_mpi_type() const
-  {
-    return MPI_DATATYPE_NULL;
-  }
-
-  // Set up MPI types (i.e., Position)
-  void init_mpi_datatypes();
-
-  // Free MPI types
-  void free_mpi_datatypes();
-
   //
   // T/H communication operations -- ultimately we want to avoid storing
   // the entire T/H solution on a single rank

--- a/src/heat_fluids_driver.cpp
+++ b/src/heat_fluids_driver.cpp
@@ -69,15 +69,13 @@ xt::xtensor<double, 1> HeatFluidsDriver::density() const
   return xt::adapt(global_densities);
 }
 
-xt::xtensor<int, 1> HeatFluidsDriver::fluid_mask() const
+std::vector<int> HeatFluidsDriver::fluid_mask() const
 {
   // Get local fluid masks
   auto local_fluid_mask = this->fluid_mask_local();
 
   // Gather all the local fluid masks onto the root
-  auto global_fluid_mask = this->gather(local_fluid_mask);
-
-  return xt::adapt(global_fluid_mask);
+  return this->gather(local_fluid_mask);
 }
 
 }

--- a/src/heat_fluids_driver.cpp
+++ b/src/heat_fluids_driver.cpp
@@ -26,4 +26,13 @@ void HeatFluidsDriver::init_displs()
   }
 }
 
+std::vector<Position> HeatFluidsDriver::centroids() const
+{
+  // Get local centroids on each rank
+  auto local_centroids = this->centroid_local();
+
+  // Gather local centroids onto root process
+  return this->gather(local_centroids);
+}
+
 }

--- a/src/heat_fluids_driver.cpp
+++ b/src/heat_fluids_driver.cpp
@@ -1,5 +1,7 @@
 #include "enrico/heat_fluids_driver.h"
-#include "gsl/gsl"
+
+#include <gsl/gsl>
+#include <xtensor/xadapt.hpp>
 
 namespace enrico {
 
@@ -42,6 +44,40 @@ std::vector<double> HeatFluidsDriver::volumes() const
 
   // Gather local centroids onto root process
   return this->gather(local_volumes);
+}
+
+xt::xtensor<double, 1> HeatFluidsDriver::temperature() const
+{
+  // Get local tempratures on each rank
+  auto local_temperatures = this->temperature_local();
+
+  // Gather all the local element temperatures onto the root
+  auto global_temperatures = this->gather(local_temperatures);
+
+  // only the return value from root should be used, or else a broadcast added here
+  return xt::adapt(global_temperatures);
+}
+
+xt::xtensor<double, 1> HeatFluidsDriver::density() const
+{
+  // Get local densities on each rank
+  auto local_densities = this->density_local();
+
+  // Gather all local element densities onto the root
+  auto global_densities = this->gather(local_densities);
+
+  return xt::adapt(global_densities);
+}
+
+xt::xtensor<int, 1> HeatFluidsDriver::fluid_mask() const
+{
+  // Get local fluid masks
+  auto local_fluid_mask = this->fluid_mask_local();
+
+  // Gather all the local fluid masks onto the root
+  auto global_fluid_mask = this->gather(local_fluid_mask);
+
+  return xt::adapt(global_fluid_mask);
 }
 
 }

--- a/src/heat_fluids_driver.cpp
+++ b/src/heat_fluids_driver.cpp
@@ -10,4 +10,20 @@ HeatFluidsDriver::HeatFluidsDriver(MPI_Comm comm, double pressure_bc)
   Expects(pressure_bc_ > 0.0);
 }
 
+void HeatFluidsDriver::init_displs()
+{
+  if (active()) {
+    local_counts_.resize(comm_.size);
+    local_displs_.resize(comm_.size);
+
+    int32_t n_local = this->n_local_elem();
+    comm_.Allgather(&n_local, 1, MPI_INT32_T, local_counts_.data(), 1, MPI_INT32_T);
+
+    local_displs_.at(0) = 0;
+    for (gsl::index i = 1; i < comm_.size; ++i) {
+      local_displs_.at(i) = local_displs_.at(i - 1) + local_counts_.at(i - 1);
+    }
+  }
+}
+
 }

--- a/src/heat_fluids_driver.cpp
+++ b/src/heat_fluids_driver.cpp
@@ -35,4 +35,13 @@ std::vector<Position> HeatFluidsDriver::centroids() const
   return this->gather(local_centroids);
 }
 
+std::vector<double> HeatFluidsDriver::volumes() const
+{
+  // Get local volumes on each rank
+  auto local_volumes = this->volume_local();
+
+  // Gather local centroids onto root process
+  return this->gather(local_volumes);
+}
+
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ int main(int argc, char* argv[])
 {
   // Initialize MPI
   MPI_Init(&argc, &argv);
+  enrico::init_mpi_datatypes();
 
   // Define enums for selecting drivers
   enum class Transport { OpenMC, Shift, Surrogate };
@@ -71,6 +72,7 @@ int main(int argc, char* argv[])
     break;
   }
 
+  enrico::free_mpi_datatypes();
   MPI_Finalize();
   return 0;
 }

--- a/src/message_passing.cpp
+++ b/src/message_passing.cpp
@@ -1,8 +1,20 @@
 #include "enrico/message_passing.h"
 
+#include "enrico/geom.h"
+
 #include <mpi.h>
 
 namespace enrico {
+
+//==============================================================================
+// Global variables
+//==============================================================================
+
+MPI_Datatype position_mpi_datatype{MPI_DATATYPE_NULL};
+
+//==============================================================================
+// Functions
+//==============================================================================
 
 void get_node_comms(MPI_Comm super_comm,
                     int procs_per_node,
@@ -30,9 +42,8 @@ void get_node_comms(MPI_Comm super_comm,
     MPI_Comm_free(sub_comm);
 }
 
-MPI_Datatype define_position_mpi_datatype()
+void init_mpi_datatypes()
 {
-
   Position p;
   int blockcounts[3] = {1, 1, 1};
   MPI_Datatype types[3] = {MPI_DOUBLE, MPI_DOUBLE, MPI_DOUBLE};
@@ -50,10 +61,30 @@ MPI_Datatype define_position_mpi_datatype()
 
   // Make datatype
   MPI_Datatype type;
-  MPI_Type_create_struct(3, blockcounts, displs, types, &type);
-  MPI_Type_commit(&type);
+  MPI_Type_create_struct(3, blockcounts, displs, types, &position_mpi_datatype);
+  MPI_Type_commit(&position_mpi_datatype);
+}
 
-  return type;
+void free_mpi_datatypes()
+{
+  MPI_Type_free(&position_mpi_datatype);
+}
+
+// Traits for mapping plain types to corresponding MPI types
+template<>
+MPI_Datatype get_mpi_type<int>()
+{
+  return MPI_INT;
+}
+template<>
+MPI_Datatype get_mpi_type<double>()
+{
+  return MPI_DOUBLE;
+}
+template<>
+MPI_Datatype get_mpi_type<Position>()
+{
+  return position_mpi_datatype;
 }
 
 } // namespace enrico

--- a/src/message_passing.cpp
+++ b/src/message_passing.cpp
@@ -60,7 +60,6 @@ void init_mpi_datatypes()
   displs[0] = 0;
 
   // Make datatype
-  MPI_Datatype type;
   MPI_Type_create_struct(3, blockcounts, displs, types, &position_mpi_datatype);
   MPI_Type_commit(&position_mpi_datatype);
 }

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -148,6 +148,16 @@ double NekDriver::volume_at(int32_t local_elem) const
   return volume;
 }
 
+std::vector<double> NekDriver::volume_local() const
+{
+  int n_local = this->n_local_elem();
+  std::vector<double> local_elem_volumes(n_local);
+  for (int32_t i = 0; i < n_local; ++i) {
+    local_elem_volumes[i] = this->volume_at(i + 1);
+  }
+  return local_elem_volumes;
+}
+
 double NekDriver::temperature_at(int32_t local_elem) const
 {
   double temperature;

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -16,10 +16,6 @@ namespace enrico {
 NekDriver::NekDriver(MPI_Comm comm, double pressure_bc, pugi::xml_node node)
   : HeatFluidsDriver(comm, pressure_bc)
 {
-  lelg_ = nek_get_lelg();
-  lelt_ = nek_get_lelt();
-  lx1_ = nek_get_lx1();
-
   if (active()) {
     casename_ = node.child_value("casename");
     if (comm_.rank == 0) {

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -44,21 +44,6 @@ void NekDriver::init_session_name()
   session_name.close();
 }
 
-void NekDriver::init_displs()
-{
-  if (active()) {
-    local_counts_.resize(comm_.size);
-    local_displs_.resize(comm_.size);
-
-    comm_.Allgather(&nelt_, 1, MPI_INT32_T, local_counts_.data(), 1, MPI_INT32_T);
-
-    local_displs_.at(0) = 0;
-    for (gsl::index i = 1; i < comm_.size; ++i) {
-      local_displs_.at(i) = local_displs_.at(i - 1) + local_counts_.at(i - 1);
-    }
-  }
-}
-
 xt::xtensor<double, 1> NekDriver::temperature() const
 {
   // Each Nek proc finds the temperatures of its local elements

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -130,6 +130,16 @@ Position NekDriver::centroid_at(int32_t local_elem) const
   return {x, y, z};
 }
 
+std::vector<Position> NekDriver::centroid_local() const
+{
+  int n_local = this->n_local_elem();
+  std::vector<Position> local_element_centroids(n_local);
+  for (int32_t i = 0; i < n_local; ++i) {
+    local_element_centroids[i] = this->centroid_at(i + 1);
+  }
+  return local_element_centroids;
+}
+
 double NekDriver::volume_at(int32_t local_elem) const
 {
   double volume;

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -56,18 +56,6 @@ std::vector<double> NekDriver::temperature_local() const
   return local_elem_temperatures;
 }
 
-xt::xtensor<double, 1> NekDriver::temperature() const
-{
-  // Get local tempratures on each rank
-  auto local_temperatures = this->temperature_local();
-
-  // Gather all the local element temperatures onto the root
-  auto global_temperatures = this->gather(local_temperatures);
-
-  // only the return value from root should be used, or else a broadcast added here
-  return xt::adapt(global_temperatures);
-}
-
 std::vector<int> NekDriver::fluid_mask_local() const
 {
   std::vector<int> local_fluid_mask(nelt_);
@@ -75,17 +63,6 @@ std::vector<int> NekDriver::fluid_mask_local() const
     local_fluid_mask[i] = this->in_fluid_at(i + 1);
   }
   return local_fluid_mask;
-}
-
-xt::xtensor<int, 1> NekDriver::fluid_mask() const
-{
-  // Get local fluid masks
-  auto local_fluid_mask = this->fluid_mask_local();
-
-  // Gather all the local fluid masks onto the root
-  auto global_fluid_mask = this->gather(local_fluid_mask);
-
-  return xt::adapt(global_fluid_mask);
 }
 
 std::vector<double> NekDriver::density_local() const
@@ -103,17 +80,6 @@ std::vector<double> NekDriver::density_local() const
   }
 
   return local_densities;
-}
-
-xt::xtensor<double, 1> NekDriver::density() const
-{
-  // Get local densities on each rank
-  auto local_densities = this->density_local();
-
-  // Gather all local element densities onto the root
-  auto global_densities = this->gather(local_densities);
-
-  return xt::adapt(global_densities);
 }
 
 void NekDriver::solve_step()

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -191,20 +191,9 @@ void OpenmcNekDriver::init_volumes()
 {
   comm_.message("Initializing volumes");
 
-  auto n_global = this->get_heat_driver().n_global_elem();
-  if (this->has_global_coupling_data()) {
-    elem_volumes_.resize(n_global);
-  }
-
   if (nek_driver_->active()) {
-    // Every Nek proc gets its local element volumes (lev)
-    int n_local = this->get_heat_driver().n_local_elem();
-    std::vector<double> local_elem_volumes(n_local);
-    for (int32_t i = 0; i < n_local; ++i) {
-      local_elem_volumes[i] = nek_driver_->volume_at(i + 1);
-    }
     // Gather all the local element volumes on the Nek5000/OpenMC root
-    elem_volumes_ = this->get_heat_driver().gather(local_elem_volumes);
+    elem_volumes_ = this->get_heat_driver().volumes();
 
     // Broadcast global_element_volumes onto all the OpenMC procs
     if (openmc_driver_->active()) {

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -81,11 +81,6 @@ HeatFluidsDriver& OpenmcNekDriver::get_heat_driver() const
   return *nek_driver_;
 }
 
-void OpenmcNekDriver::init_mpi_datatypes()
-{
-  position_mpi_datatype = define_position_mpi_datatype();
-}
-
 void OpenmcNekDriver::init_mappings()
 {
   comm_.message("Initializing mappings");
@@ -439,11 +434,6 @@ void OpenmcNekDriver::set_density()
       }
     }
   }
-}
-
-void OpenmcNekDriver::free_mpi_datatypes()
-{
-  MPI_Type_free(&position_mpi_datatype);
 }
 
 } // namespace enrico

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -43,7 +43,6 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
   openmc_driver_ = std::make_unique<OpenmcDriver>(openmc_comm);
   nek_driver_ = std::make_unique<NekDriver>(comm, pressure_bc, nek_node);
 
-  init_mpi_datatypes();
   init_mappings();
   init_tallies();
   init_volumes();
@@ -55,11 +54,6 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
   init_temperatures();
   init_densities();
   init_heat_source();
-}
-
-OpenmcNekDriver::~OpenmcNekDriver()
-{
-  free_mpi_datatypes();
 }
 
 bool OpenmcNekDriver::has_global_coupling_data() const

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -82,15 +82,8 @@ void OpenmcNekDriver::init_mappings()
   comm_.message("Initializing mappings");
 
   if (nek_driver_->active()) {
-    // Step 1: Get global element centroids/fluid-identities on all OpenMC ranks
-    // Each Nek proc finds the centroids/fluid-identities of its local elements
-    int n_local = this->get_heat_driver().n_local_elem();
-    std::vector<Position> local_element_centroids(n_local);
-    for (int32_t i = 0; i < n_local; ++i) {
-      local_element_centroids[i] = nek_driver_->centroid_at(i + 1);
-    }
-    // Gather all the local element centroids/fluid-identities on the Nek5000/OpenMC root
-    elem_centroids_ = this->get_heat_driver().gather(local_element_centroids);
+    // Get centroids from heat driver
+    elem_centroids_ = this->get_heat_driver().centroids();
 
     // Broadcast global_element_centroids/fluid-identities onto all the OpenMC procs
     if (openmc_driver_->active()) {


### PR DESCRIPTION
In our `OpenmcNekDriver`, we commonly use `MPI_Gatherv` to take a local quantity in Nek that is distributed over all ranks and gather it only the root process. The primary change in this PR is to collect that logic into a single method (`HeatFluidsDriver::gather`). This method is also templated based on the datatype that is being communicated. Altogether this required/inspired other associated changes:

- I've extracted `get_mpi_type<T>()` from ShiftNekDriver and placed it in our message_passing module
- `position_mpi_datatype` is now a global variable and is initialized separately from the drivers themselves
- `local_counts_` and `local_displs_` is now owned by the `HeatFluidsDriver` class
- `HeatFluidsDriver` now has new abstract methods (`temperature_local`, `density_local`, etc.) that subclasses are expected to define. Ideally, this would be pure virtual, but `OpenmcHeatDriver` doesn't use it yet.
- `NeutronicsDriver` has a `broadcast` templated method that will broadcast data across the neutronics communicator, again depending on the type.

My ultimate goal is to get `OpenmcNekDriver` generic enough that it doesn't really refer to the `nek_driver_` or `openmc_driver_` members specifically but instead relies on generic capabilities of the heat-fluids / neutronics drivers. This PR makes substantial progress on the Nek side (you'll see there are few references to `nek_driver_` remaining.