### PR TITLE
Define/use abstract methods for neutronics drivers

### DIFF
--- a/include/enrico/driver.h
+++ b/include/enrico/driver.h
@@ -42,28 +42,8 @@ public:
   //! \return True if this comm's solver is not MPI_COMM_NULL
   bool active() const;
 
-  //! Broadcast data across ranks, possibly resizing vector
-  //! \param values Values to broadcast (significant at rank 0)
-  template<typename T>
-  void broadcast(std::vector<T>& values) const;
-
   Comm comm_; //!< The MPI communicator used to run the solver
 };
-
-template<typename T>
-void Driver::broadcast(std::vector<T>& values) const
-{
-  if (this->active()) {
-    // First broadcast the size of the vector
-    int n = values.size();
-    comm_.Bcast(&n, 1, MPI_INT);
-
-    // Resize vector (for rank != 0) and broacast data
-    if (values.size() != n)
-      values.resize(n);
-    comm_.Bcast(values.data(), n, get_mpi_type<T>());
-  }
-}
 
 } // namespace enrico
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -40,6 +40,8 @@ public:
   //! \return For each region, 1 if region is in fluid and 0 otherwise
   std::vector<int> fluid_mask() const;
 
+  virtual int set_heat_source_at(int32_t local_elem, double heat) const { return 0; }
+
   //! Get the number of local mesh elements
   //! \return Number of local mesh elements
   // TODO: make pure virtual and remove implementation

--- a/include/enrico/message_passing.h
+++ b/include/enrico/message_passing.h
@@ -3,8 +3,7 @@
 #ifndef ENRICO_MESSAGE_PASSING_H
 #define ENRICO_MESSAGE_PASSING_H
 
-#include "geom.h"
-#include "mpi.h"
+#include <mpi.h>
 
 //! The ENRICO namespace
 namespace enrico {
@@ -62,10 +61,7 @@ void free_mpi_datatypes();
 
 //! Map types to corresponding MPI datatypes
 template<typename T>
-MPI_Datatype get_mpi_type()
-{
-  return MPI_DATATYPE_NULL;
-}
+MPI_Datatype get_mpi_type();
 
 } // namespace enrico
 

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -89,7 +89,7 @@ public:
   //! \param local_elem A local element ID
   //! \param heat A heat source term
   //! \return Error code
-  int set_heat_source_at(int32_t local_elem, double heat);
+  int set_heat_source_at(int32_t local_elem, double heat) const override;
 
   //! Get the number of local mesh elements
   //! \return Number of local mesh elements

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -29,15 +29,46 @@ public:
   //! \return Heat source in each material as [W/cm3]
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
 
+  //! Find cells corresponding to a vector of positions
+  //! \param positions (x,y,z) coordinates to search for
+  //! \return Handles to cells
   virtual std::vector<CellHandle> find(const std::vector<Position>& positions) = 0;
+
+  //! Set the density of the material in a cell
+  //! \param cell Handle to a cell
+  //! \param rho Density in [g/cm^3]
   virtual void set_density(CellHandle cell, double rho) const = 0;
+
+  //! Set the temperature of a cell
+  //! \param cell Handle to a cell
+  //! \param T Temperature in [K]
   virtual void set_temperature(CellHandle cell, double T) const = 0;
+
+  //! Get the density of a cell
+  //! \param cell Handle to a cell
+  //! \return Cell density in [g/cm^3]
   virtual double get_density(CellHandle cell) const = 0;
+
+  //! Get the temperature of a cell
+  //! \param cell Handle to a cell
+  //! \return Temperature in [K]
   virtual double get_temperature(CellHandle cell) const = 0;
+
+  //! Get the volume of a cell
+  //! \param cell Handle to a cell
+  //! \return Volume in [cm^3]
   virtual double get_volume(CellHandle cell) const = 0;
+
+  //! Detemrine whether a cell contains fissionable nuclides
+  //! \param cell Handle to a cell
+  //! \return Whether the cell contains fissionable nuclides
   virtual bool is_fissionable(CellHandle cell) const = 0;
+
+  //! Determine number of cells participating in coupling
+  //! \return Number of cells
   virtual std::size_t n_cells() const = 0;
 
+  //! Create energy production tallies
   // TODO: Remove argument
   virtual void create_tallies(std::size_t n) = 0;
 };

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -6,9 +6,14 @@
 #include "enrico/driver.h"
 #include "enrico/message_passing.h"
 
-#include "xtensor/xtensor.hpp"
+#include <gsl/gsl>
+#include <xtensor/xtensor.hpp>
+
+#include <vector>
 
 namespace enrico {
+
+using CellHandle = gsl::index;
 
 //! Base class for driver that controls a neutronics solve
 class NeutronicsDriver : public Driver {
@@ -23,6 +28,18 @@ public:
   //! \param power User-specified power in [W]
   //! \return Heat source in each material as [W/cm3]
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
+
+  virtual std::vector<CellHandle> find(const std::vector<Position>& positions) = 0;
+  virtual void set_density(CellHandle cell, double rho) const = 0;
+  virtual void set_temperature(CellHandle cell, double T) const = 0;
+  virtual double get_density(CellHandle cell) const = 0;
+  virtual double get_temperature(CellHandle cell) const = 0;
+  virtual double get_volume(CellHandle cell) const = 0;
+  virtual bool is_fissionable(CellHandle cell) const = 0;
+  virtual std::size_t n_cells() const = 0;
+
+  // TODO: Remove argument
+  virtual void create_tallies(std::size_t n) = 0;
 };
 
 } // namespace enrico

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -4,6 +4,7 @@
 #define NEUTRONICS_DRIVER_H
 
 #include "enrico/driver.h"
+#include "enrico/geom.h"
 #include "enrico/message_passing.h"
 
 #include <gsl/gsl>

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -3,9 +3,9 @@
 #ifndef ENRICO_OPENMC_DRIVER_H
 #define ENRICO_OPENMC_DRIVER_H
 
-#include "cell_instance.h"
-#include "geom.h"
-#include "neutronics_driver.h"
+#include "enrico/cell_instance.h"
+#include "enrico/geom.h"
+#include "enrico/neutronics_driver.h"
 
 #include "openmc/cell.h"
 #include "openmc/tallies/filter_cell_instance.h"
@@ -27,9 +27,18 @@ public:
   //! One-time finalization of OpenMC
   ~OpenmcDriver();
 
+  std::vector<CellHandle> find(const std::vector<Position>& position) override;
+  void set_density(CellHandle cell, double rho) const override;
+  void set_temperature(CellHandle cell, double T) const override;
+  double get_density(CellHandle cell) const override;
+  double get_temperature(CellHandle cell) const override;
+  double get_volume(CellHandle cell) const override;
+  bool is_fissionable(CellHandle cell) const override;
+  std::size_t n_cells() const override { return cells_.size(); }
+
   //! Create energy production tallies for a list of cell instances
   //! \param[in] cells  Sequence of OpenMC cell instances
-  void create_tallies(gsl::span<openmc::CellInstance> cells);
+  void create_tallies(std::size_t n) override;
 
   xt::xtensor<double, 1> heat_source(double power) const final;
 

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -27,19 +27,48 @@ public:
   //! One-time finalization of OpenMC
   ~OpenmcDriver();
 
+  //! Find cells corresponding to a vector of positions
+  //! \param positions (x,y,z) coordinates to search for
+  //! \return Handles to cells
   std::vector<CellHandle> find(const std::vector<Position>& position) override;
+
+  //! Set the density of the material in a cell
+  //! \param cell Handle to a cell
+  //! \param rho Density in [g/cm^3]
   void set_density(CellHandle cell, double rho) const override;
+
+  //! Set the temperature of a cell
+  //! \param cell Handle to a cell
+  //! \param T Temperature in [K]
   void set_temperature(CellHandle cell, double T) const override;
+
+  //! Get the density of a cell
+  //! \param cell Handle to a cell
+  //! \return Cell density in [g/cm^3]
   double get_density(CellHandle cell) const override;
+
+  //! Get the temperature of a cell
+  //! \param cell Handle to a cell
+  //! \return Temperature in [K]
   double get_temperature(CellHandle cell) const override;
+
+  //! Get the volume of a cell
+  //! \param cell Handle to a cell
+  //! \return Volume in [cm^3]
   double get_volume(CellHandle cell) const override;
+
+  //! Detemrine whether a cell contains fissionable nuclides
+  //! \param cell Handle to a cell
+  //! \return Whether the cell contains fissionable nuclides
   bool is_fissionable(CellHandle cell) const override;
+
   std::size_t n_cells() const override { return cells_.size(); }
 
-  //! Create energy production tallies for a list of cell instances
-  //! \param[in] cells  Sequence of OpenMC cell instances
+  //! Create energy production tallies
   void create_tallies(std::size_t n) override;
 
+  //! Determine number of cells participating in coupling
+  //! \return Number of cells
   xt::xtensor<double, 1> heat_source(double power) const final;
 
   //! Initialization required in each Picard iteration

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -4,12 +4,13 @@
 #define ENRICO_OPENMC_NEK_DRIVER_H
 
 #include "enrico/coupled_driver.h"
+#include "enrico/heat_fluids_driver.h"
 #include "enrico/message_passing.h"
-#include "enrico/nek_driver.h"
-#include "enrico/openmc_driver.h"
-#include "mpi.h"
+#include "enrico/neutronics_driver.h"
 
-#include <unordered_set>
+#include <mpi.h>
+
+#include <unordered_map>
 
 namespace enrico {
 
@@ -91,9 +92,8 @@ private:
   //! Initialize global volume buffers for OpenMC ranks
   void init_volumes();
 
-  std::unique_ptr<OpenmcDriver> openmc_driver_; //!< The OpenMC driver
-
-  std::unique_ptr<NekDriver> nek_driver_; //!< The Nek5000 driver
+  std::unique_ptr<NeutronicsDriver> neutronics_driver_;  //!< The neutronics driver
+  std::unique_ptr<HeatFluidsDriver> heat_fluids_driver_; //!< The heat-fluids driver
 
   //! States whether a global element is in the fluid region
   //! These are **not** ordered by Nek's global element indices.  Rather, these are

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -95,11 +95,6 @@ private:
 
   std::unique_ptr<NekDriver> nek_driver_; //!< The Nek5000 driver
 
-  //! Gives a Position of a global element's centroid
-  //! These are **not** ordered by Nek's global element indices.  Rather, these are
-  //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
-  std::vector<Position> elem_centroids_;
-
   //! States whether a global element is in the fluid region
   //! These are **not** ordered by Nek's global element indices.  Rather, these are
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -108,17 +108,17 @@ private:
   //! ordered according to an MPI_Gatherv operation on Nek5000's local elements.
   std::vector<double> elem_volumes_;
 
-  //! Map that gives a list of Nek element global indices for a given OpenMC
-  //! cell instance index. The Nek global element indices refer to indices
-  //! defined by the MPI_Gatherv operation, and do not reflect Nek's internal
-  //! global element indexing.
-  std::unordered_map<int32_t, std::vector<int32_t>> cell_to_elems_;
-
-  //! Map that gives the OpenMC cell instance indices for a given Nek global
-  //! element index. The Nek global element indices refer to indices defined by
+  //! Map that gives a list of Nek element global indices for a given neutronics
+  //! cell handle. The Nek global element indices refer to indices defined by
   //! the MPI_Gatherv operation, and do not reflect Nek's internal global
   //! element indexing.
-  std::vector<int32_t> elem_to_cell_;
+  std::unordered_map<CellHandle, std::vector<int32_t>> cell_to_elems_;
+
+  //! Map that gives the neutronics cell handle for a given Nek global element
+  //! index. The Nek global element indices refer to indices defined by the
+  //! MPI_Gatherv operation, and do not reflect Nek's internal global element
+  //! indexing.
+  std::vector<CellHandle> elem_to_cell_;
 
   //! Number of cell instances in OpenMC model
   int32_t n_cells_;

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -4,7 +4,7 @@ namespace enrico {
 
 bool Driver::active() const
 {
-  return comm_.comm != MPI_COMM_NULL;
+  return comm_.active();
 }
 
 } // namespace enrico

--- a/src/message_passing.cpp
+++ b/src/message_passing.cpp
@@ -69,17 +69,61 @@ void free_mpi_datatypes()
   MPI_Type_free(&position_mpi_datatype);
 }
 
-// Traits for mapping plain types to corresponding MPI types
+// Traits for mapping plain types to corresponding MPI types (ints)
+template<>
+MPI_Datatype get_mpi_type<char>()
+{
+  return MPI_CHAR;
+}
+template<>
+MPI_Datatype get_mpi_type<short>()
+{
+  return MPI_SHORT;
+}
 template<>
 MPI_Datatype get_mpi_type<int>()
 {
   return MPI_INT;
 }
 template<>
+MPI_Datatype get_mpi_type<long>()
+{
+  return MPI_LONG;
+}
+template<>
+MPI_Datatype get_mpi_type<long long>()
+{
+  return MPI_LONG_LONG;
+}
+template<>
+MPI_Datatype get_mpi_type<unsigned int>()
+{
+  return MPI_UNSIGNED;
+}
+template<>
+MPI_Datatype get_mpi_type<unsigned long>()
+{
+  return MPI_UNSIGNED_LONG;
+}
+template<>
+MPI_Datatype get_mpi_type<unsigned long long>()
+{
+  return MPI_UNSIGNED_LONG_LONG;
+}
+
+// Traits for mapping plain types to corresponding MPI types (reals)
+template<>
+MPI_Datatype get_mpi_type<float>()
+{
+  return MPI_FLOAT;
+}
+template<>
 MPI_Datatype get_mpi_type<double>()
 {
   return MPI_DOUBLE;
 }
+
+// Traits for mapping plain types to corresponding MPI types (user defined)
 template<>
 MPI_Datatype get_mpi_type<Position>()
 {

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -137,8 +137,9 @@ int NekDriver::in_fluid_at(int32_t local_elem) const
   return nek_local_elem_is_in_fluid(local_elem);
 }
 
-int NekDriver::set_heat_source_at(int32_t local_elem, double heat)
+int NekDriver::set_heat_source_at(int32_t local_elem, double heat) const
 {
+  Expects(local_elem >= 1 && local_elem <= nelt_);
   return nek_set_heat_source(local_elem, heat);
 }
 

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -12,8 +12,10 @@
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xview.hpp"
+#include <gsl/gsl>
 
 #include <string>
+#include <unordered_map>
 
 namespace enrico {
 
@@ -51,14 +53,24 @@ OpenmcDriver::OpenmcDriver(MPI_Comm comm)
   }
 }
 
-void OpenmcDriver::create_tallies(gsl::span<openmc::CellInstance> cells)
+void OpenmcDriver::create_tallies(std::size_t n)
 {
+  using gsl::index;
+  using gsl::narrow_cast;
+
+  // Build vector of material indices
+  std::vector<openmc::CellInstance> instances;
+  for (index i = 0; i < n; ++i) {
+    const auto& c = cells_[i];
+    instances.push_back({narrow_cast<index>(c.index_), narrow_cast<index>(c.instance_)});
+  }
+
   // Create material filter
   auto f = openmc::Filter::create("cellinstance");
   filter_ = dynamic_cast<openmc::CellInstanceFilter*>(f);
 
   // Set bins for filter
-  filter_->set_cell_instances(cells);
+  filter_->set_cell_instances(instances);
 
   // Create tally and assign scores/filters
   tally_ = openmc::Tally::create();
@@ -93,6 +105,63 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
   }
 
   return heat;
+}
+
+std::vector<CellHandle> OpenmcDriver::find(const std::vector<Position>& positions)
+{
+  std::vector<CellHandle> handles;
+  handles.reserve(positions.size());
+
+  std::unordered_map<CellInstance, CellHandle> cell_index;
+
+  for (const auto& r : positions) {
+    // Determine cell instance corresponding to global element
+    CellInstance c{r};
+
+    // If this cell instance hasn't been saved yet, add it to cells_ and
+    // keep track of what index it corresponds to
+    if (cell_index.find(c) == cell_index.end()) {
+      cell_index[c] = cells_.size();
+      cells_.push_back(c);
+    }
+    auto h = cell_index.at(c);
+
+    // Set value for cell instance in array
+    handles.push_back(h);
+  }
+  return handles;
+}
+
+void OpenmcDriver::set_density(CellHandle cell, double rho) const
+{
+  cells_[cell].material()->set_density(rho, "g/cm3");
+}
+
+void OpenmcDriver::set_temperature(CellHandle cell, double T) const
+{
+  const auto& c = cells_[cell];
+  c.cell()->set_temperature(T, c.instance_);
+}
+
+double OpenmcDriver::get_density(CellHandle cell) const
+{
+  return cells_[cell].material()->density();
+}
+
+double OpenmcDriver::get_temperature(CellHandle cell) const
+{
+  const auto& c = cells_[cell];
+  return c.cell()->temperature(c.instance_);
+}
+
+double OpenmcDriver::get_volume(CellHandle cell) const
+{
+  return cells_[cell].volume_;
+}
+
+bool OpenmcDriver::is_fissionable(CellHandle cell) const
+{
+  return cells_[cell].material()->fissionable();
 }
 
 void OpenmcDriver::init_step()

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -181,20 +181,8 @@ void OpenmcHeatDriver::init_mappings()
 
 void OpenmcHeatDriver::init_tallies()
 {
-  using gsl::index;
-  using gsl::narrow_cast;
-
   if (openmc_driver_->active()) {
-    // Build vector of cell instances to construct tallies; tallies are only
-    // used in the solid regions
-    std::vector<openmc::CellInstance> cells;
-    for (gsl::index c = 0; c < n_solid_cells_; ++c) {
-      const auto& cell = openmc_driver_->cells_[c];
-      cells.push_back(
-        {narrow_cast<index>(cell.index_), narrow_cast<index>(cell.instance_)});
-    }
-
-    openmc_driver_->create_tallies(cells);
+    openmc_driver_->create_tallies(n_solid_cells_);
   }
 }
 

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -284,20 +284,21 @@ void OpenmcNekDriver::set_heat_source()
   // source available on each Nek rank.
   intranode_comm_.Bcast(heat_source_.data(), n_cells_, MPI_DOUBLE);
 
-  if (nek_driver_->active()) {
+  auto& heat = this->get_heat_driver();
+  if (heat.active()) {
     // Determine displacement for this rank
-    auto displacement = nek_driver_->local_displs_[nek_driver_->comm_.rank];
+    auto displacement = heat.local_displs_[heat.comm_.rank];
 
     // Loop over local elements to set heat source
-    int n_local = this->get_heat_driver().n_local_elem();
+    int n_local = heat.n_local_elem();
     for (int32_t local_elem = 1; local_elem <= n_local; ++local_elem) {
       // get corresponding global element
-      int32_t global_index = local_elem + displacement - 1;
+      int32_t global_elem = local_elem + displacement - 1;
 
       // get index to cell instance
-      int32_t cell_index = elem_to_cell_.at(global_index);
+      CellHandle cell = elem_to_cell_.at(global_elem);
 
-      err_chk(nek_driver_->set_heat_source_at(local_elem, heat_source_[cell_index]),
+      err_chk(heat.set_heat_source_at(local_elem, heat_source_[cell]),
               "Error setting heat source for local element " +
                 std::to_string(local_elem));
     }

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -3,6 +3,8 @@
 #include "enrico/const.h"
 #include "enrico/error.h"
 #include "enrico/message_passing.h"
+#include "enrico/nek_driver.h"
+#include "enrico/openmc_driver.h"
 
 #include "gsl/gsl"
 #include "nek5000/core/nek_interface.h"
@@ -40,8 +42,8 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
   intranode_comm_ = Comm(intranode_comm);
 
   // Instantiate OpenMC and Nek drivers
-  openmc_driver_ = std::make_unique<OpenmcDriver>(openmc_comm);
-  nek_driver_ = std::make_unique<NekDriver>(comm, pressure_bc, nek_node);
+  neutronics_driver_ = std::make_unique<OpenmcDriver>(openmc_comm);
+  heat_fluids_driver_ = std::make_unique<NekDriver>(comm, pressure_bc, nek_node);
 
   init_mappings();
   init_tallies();
@@ -58,17 +60,17 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
 
 bool OpenmcNekDriver::has_global_coupling_data() const
 {
-  return openmc_driver_->active() && nek_driver_->active();
+  return this->get_neutronics_driver().active() && this->get_heat_driver().active();
 }
 
 NeutronicsDriver& OpenmcNekDriver::get_neutronics_driver() const
 {
-  return *openmc_driver_;
+  return *neutronics_driver_;
 }
 
 HeatFluidsDriver& OpenmcNekDriver::get_heat_driver() const
 {
-  return *nek_driver_;
+  return *heat_fluids_driver_;
 }
 
 void OpenmcNekDriver::init_mappings()

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -83,7 +83,7 @@ void OpenmcNekDriver::init_mappings()
     auto elem_centroids = heat.centroids();
 
     // Broadcast centroids onto all the neutronics procs
-    this->get_neutronics_driver().broadcast(elem_centroids);
+    this->get_neutronics_driver().comm_.broadcast(elem_centroids);
 
     // Set element->cell and cell->element mappings. Create buffer to store cell
     // handles corresponding to each heat-fluids global element.
@@ -105,7 +105,7 @@ void OpenmcNekDriver::init_mappings()
     }
 
     // Set element -> cell instance mapping on each Nek rank
-    intranode_comm_.Bcast(elem_to_cell_.data(), elem_to_cell_.size(), MPI_UINT64_T);
+    intranode_comm_.broadcast(elem_to_cell_);
 
     // Broadcast number of cell instances
     intranode_comm_.Bcast(&n_cells_, 1, MPI_INT32_T);
@@ -169,7 +169,7 @@ void OpenmcNekDriver::init_volumes()
     elem_volumes_ = heat.volumes();
 
     // Broadcast global_element_volumes onto all the OpenMC procs
-    this->get_neutronics_driver().broadcast(elem_volumes_);
+    this->get_neutronics_driver().comm_.broadcast(elem_volumes_);
   }
 
   // Volume check
@@ -252,7 +252,7 @@ void OpenmcNekDriver::init_elem_fluid_mask()
     elem_fluid_mask_ = heat.fluid_mask();
 
     // Broadcast fluid mask to neutronics driver
-    this->get_neutronics_driver().broadcast(elem_fluid_mask_);
+    this->get_neutronics_driver().comm_.broadcast(elem_fluid_mask_);
   }
 }
 

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -180,10 +180,16 @@ void OpenmcNekDriver::init_volumes()
       for (const auto& elem : cell_to_elems_.at(cell)) {
         v_nek += elem_volumes_.at(elem);
       }
-      // std::stringstream msg;
-      // msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
-      //     << "), V = " << v_openmc << " (OpenMC), " << v_nek << " (Nek)";
-      // comm_.message(msg.str());
+
+      // TODO: Refactor to avoid dynamic_cast
+      const auto* openmc_driver = dynamic_cast<const OpenmcDriver*>(&neutronics);
+      if (openmc_driver) {
+        const auto& c = openmc_driver->cells_[cell];
+        std::stringstream msg;
+        msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
+            << "), V = " << v_openmc << " (OpenMC), " << v_nek << " (Nek)";
+        comm_.message(msg.str());
+      }
     }
   }
 }

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -83,39 +83,27 @@ void OpenmcNekDriver::init_mappings()
     // Broadcast centroids onto all the neutronics procs
     this->get_neutronics_driver().broadcast(elem_centroids);
 
-    // Step 2: Set element->cell and cell->element mappings
-    // Create buffer to store cell instance indices corresponding to each Nek global
-    // element. This is needed because calls to OpenMC API functions can only be
-    // made from processes
-    std::vector<int32_t> elem_to_cell(heat.n_global_elem());
+    // Set element->cell and cell->element mappings. Create buffer to store cell
+    // handles corresponding to each heat-fluids global element.
+    std::vector<CellHandle> elem_to_cell(heat.n_global_elem());
 
-    if (openmc_driver_->active()) {
-      std::unordered_map<CellInstance, index> cell_index;
+    auto& neutronics = this->get_neutronics_driver();
+    if (neutronics.active()) {
+      // Get cell handle corresponding to each element centroid
+      elem_to_cell = neutronics.find(elem_centroids);
 
-      for (int32_t i = 0; i < elem_to_cell.size(); ++i) {
-        // Determine cell instance corresponding to global element
-        Position elem_pos = elem_centroids[i];
-        CellInstance c{elem_pos};
-
-        // If this cell instance hasn't been saved yet, add it to cells_ and
-        // keep track of what index it corresponds to
-        if (cell_index.find(c) == cell_index.end()) {
-          cell_index[c] = openmc_driver_->cells_.size();
-          openmc_driver_->cells_.push_back(c);
-        }
-        auto i_cell = cell_index.at(c);
-        cell_to_elems_[i_cell].push_back(i);
-
-        // Set value for cell instance in array
-        elem_to_cell[i] = i_cell;
+      // Create a vector of elements for each neutronics cell
+      for (int32_t elem = 0; elem < elem_to_cell.size(); ++elem) {
+        auto cell = elem_to_cell[elem];
+        cell_to_elems_[cell].push_back(elem);
       }
 
       // Determine number of OpenMC cell instances
-      n_cells_ = gsl::narrow<int32_t>(openmc_driver_->cells_.size());
+      n_cells_ = cell_to_elems_.size();
     }
 
     // Set element -> cell instance mapping on each Nek rank
-    intranode_comm_.Bcast(elem_to_cell.data(), elem_to_cell.size(), MPI_INT32_T);
+    intranode_comm_.Bcast(elem_to_cell.data(), elem_to_cell.size(), MPI_UINT64_T);
     elem_to_cell_ = elem_to_cell;
 
     // Broadcast number of cell instances
@@ -125,18 +113,13 @@ void OpenmcNekDriver::init_mappings()
 
 void OpenmcNekDriver::init_tallies()
 {
-  using gsl::narrow_cast;
 
   comm_.message("Initializing tallies");
 
-  if (openmc_driver_->active()) {
-    // Build vector of material indices
-    std::vector<openmc::CellInstance> instances;
-    for (const auto& c : openmc_driver_->cells_) {
-      instances.push_back(
-        {narrow_cast<index>(c.index_), narrow_cast<index>(c.instance_)});
-    }
-    openmc_driver_->create_tallies(instances);
+  auto& neutronics = this->get_neutronics_driver();
+  if (neutronics.active()) {
+    auto n = cell_to_elems_.size();
+    neutronics.create_tallies(n);
   }
 }
 
@@ -150,20 +133,16 @@ void OpenmcNekDriver::init_temperatures()
     temperatures_prev_.resize({n_global});
 
     if (temperature_ic_ == Initial::neutronics) {
-      // Loop over the OpenMC cells, then loop over the global Nek elements
-      // corresponding to that cell and assign the OpenMC cell temperature to
-      // the correct index in the temperatures_ array. This mapping assumes that
-      // each Nek element is fully contained within an OpenMC cell, i.e. Nek elements
-      // are not split between multiple OpenMC cells.
-      for (index i = 0; i < openmc_driver_->cells_.size(); ++i) {
-        const auto& global_elems = cell_to_elems_.at(i);
-        const auto& c = openmc_driver_->cells_[i];
-
-        for (auto elem : global_elems) {
-          double T = c.get_temperature();
-          temperatures_[elem] = T;
-          temperatures_prev_[elem] = T;
-        }
+      // Loop over heat-fluids elements and determine temperature based on
+      // corresponding neutronics cell. This mapping assumes that each
+      // heat-fluids element is fully contained within a neutronic cell, i.e.,
+      // heat-fluids elements are not split between multiple neutronics cells.
+      const auto& neutronics = this->get_neutronics_driver();
+      for (index elem = 0; elem < elem_to_cell_.size(); ++elem) {
+        auto cell = elem_to_cell_[elem];
+        double T = neutronics.get_temperature(cell);
+        temperatures_[elem] = T;
+        temperatures_prev_[elem] = T;
       }
     } else if (temperature_ic_ == Initial::heat) {
       // Use whatever temperature is in Nek's internal arrays, either from a restart
@@ -194,17 +173,17 @@ void OpenmcNekDriver::init_volumes()
 
   // Volume check
   if (this->has_global_coupling_data()) {
-    for (index i = 0; i < openmc_driver_->cells_.size(); ++i) {
-      const auto& c = openmc_driver_->cells_[i];
-      double v_openmc = c.volume_;
+    const auto& neutronics = this->get_neutronics_driver();
+    for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
+      double v_openmc = neutronics.get_volume(cell);
       double v_nek = 0.0;
-      for (const auto& elem : cell_to_elems_.at(i)) {
+      for (const auto& elem : cell_to_elems_.at(cell)) {
         v_nek += elem_volumes_.at(elem);
       }
-      std::stringstream msg;
-      msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
-          << "), V = " << v_openmc << " (OpenMC), " << v_nek << " (Nek)";
-      comm_.message(msg.str());
+      // std::stringstream msg;
+      // msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
+      //     << "), V = " << v_openmc << " (OpenMC), " << v_nek << " (Nek)";
+      // comm_.message(msg.str());
     }
   }
 }
@@ -224,13 +203,13 @@ void OpenmcNekDriver::init_densities()
       // the correct index in the densities_ array. This mapping assumes that
       // each Nek element is fully contained within an OpenMC cell, i.e. Nek
       // elements are not split between multiple OpenMC cells.
-      for (index i = 0; i < openmc_driver_->cells_.size(); ++i) {
-        auto& c = openmc_driver_->cells_[i];
-        const auto& global_elems = cell_to_elems_.at(i);
+      const auto& neutronics = this->get_neutronics_driver();
+      for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
+        const auto& global_elems = cell_to_elems_.at(cell);
 
-        if (cell_fluid_mask_[i] == 1) {
+        if (cell_fluid_mask_[cell] == 1) {
           for (int elem : global_elems) {
-            double rho = c.get_density();
+            double rho = neutronics.get_density(cell);
             densities_[elem] = rho;
             densities_prev_[elem] = rho;
           }
@@ -275,17 +254,17 @@ void OpenmcNekDriver::init_cell_fluid_mask()
   comm_.message("Initializing cell fluid mask");
 
   if (this->has_global_coupling_data()) {
-    auto& cells = openmc_driver_->cells_;
-    cell_fluid_mask_.resize({cells.size()});
+    auto n = cell_to_elems_.size();
+    cell_fluid_mask_.resize({n});
 
-    for (index i = 0; i < cells.size(); ++i) {
-      auto elems = cell_to_elems_.at(i);
-      for (const auto& j : elems) {
-        if (elem_fluid_mask_[j] == 1) {
-          cell_fluid_mask_[i] = 1;
+    for (CellHandle cell = 0; cell < n; ++cell) {
+      auto elems = cell_to_elems_.at(cell);
+      for (const auto& elem : elems) {
+        if (elem_fluid_mask_[elem] == 1) {
+          cell_fluid_mask_[cell] = 1;
           break;
         }
-        cell_fluid_mask_[i] = 0;
+        cell_fluid_mask_[cell] = 0;
       }
     }
   }
@@ -328,16 +307,16 @@ void OpenmcNekDriver::set_heat_source()
 void OpenmcNekDriver::set_temperature()
 {
   if (this->get_heat_driver().active()) {
-    if (openmc_driver_->active()) {
+    auto& neutronics = this->get_neutronics_driver();
+    if (neutronics.active()) {
       // Broadcast global_element_temperatures onto all the OpenMC procs
-      openmc_driver_->comm_.Bcast(temperatures_.data(), temperatures_.size(), MPI_DOUBLE);
+      neutronics.comm_.Bcast(temperatures_.data(), temperatures_.size(), MPI_DOUBLE);
 
       // For each OpenMC cell instance, volume average temperatures and set
-      for (size_t i = 0; i < openmc_driver_->cells_.size(); ++i) {
+      for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
 
         // Get corresponding global elements
-        const auto& global_elems = cell_to_elems_.at(i);
-        auto& c{openmc_driver_->cells_[i]};
+        const auto& global_elems = cell_to_elems_.at(cell);
 
         // Get volume-average temperature for this cell instance
         double average_temp = 0.0;
@@ -352,7 +331,7 @@ void OpenmcNekDriver::set_temperature()
         // Set temperature for cell instance
         average_temp /= total_vol;
         Ensures(average_temp > 0.0);
-        c.set_temperature(average_temp);
+        neutronics.set_temperature(cell, average_temp);
       }
     }
   }
@@ -364,24 +343,24 @@ void OpenmcNekDriver::set_density()
     // Since OpenMC's and Nek's master ranks are the same, we know that elem_densities_ on
     // OpenMC's master rank were updated.  Now we broadcast to the other OpenMC ranks.
     // TODO: This won't work if the Nek/OpenMC communicators are disjoint
-    if (openmc_driver_->active()) {
-      openmc_driver_->comm_.Bcast(densities_.data(), densities_.size(), MPI_DOUBLE);
+    auto& neutronics = this->get_neutronics_driver();
+    if (neutronics.active()) {
+      neutronics.comm_.Bcast(densities_.data(), densities_.size(), MPI_DOUBLE);
 
       // For each OpenMC cell instance in a fluid cell, volume average the
       // densities and set
       // TODO:  Might be able to use xtensor masking to do some of this
-      for (index i = 0; i < openmc_driver_->cells_.size(); ++i) {
-        if (cell_fluid_mask_[i] == 1) {
-          auto& c = openmc_driver_->cells_[i];
+      for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
+        if (cell_fluid_mask_[cell] == 1) {
           double average_density = 0.0;
           double total_vol = 0.0;
-          for (int e : cell_to_elems_.at(i)) {
+          for (int e : cell_to_elems_.at(cell)) {
             average_density += densities_[e] * elem_volumes_[e];
             total_vol += elem_volumes_[e];
           }
           double density = average_density / total_vol;
           Ensures(density > 0.0);
-          c.set_density(average_density / total_vol);
+          neutronics.set_density(cell, average_density / total_vol);
         }
       }
     }

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -78,10 +78,10 @@ void OpenmcNekDriver::init_mappings()
   const auto& heat = this->get_heat_driver();
   if (heat.active()) {
     // Get centroids from heat driver
-    elem_centroids_ = heat.centroids();
+    auto elem_centroids = heat.centroids();
 
     // Broadcast centroids onto all the neutronics procs
-    this->get_neutronics_driver().broadcast(elem_centroids_);
+    this->get_neutronics_driver().broadcast(elem_centroids);
 
     // Step 2: Set element->cell and cell->element mappings
     // Create buffer to store cell instance indices corresponding to each Nek global
@@ -94,7 +94,7 @@ void OpenmcNekDriver::init_mappings()
 
       for (int32_t i = 0; i < elem_to_cell.size(); ++i) {
         // Determine cell instance corresponding to global element
-        Position elem_pos = elem_centroids_[i];
+        Position elem_pos = elem_centroids[i];
         CellInstance c{elem_pos};
 
         // If this cell instance hasn't been saved yet, add it to cells_ and

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -85,16 +85,16 @@ void OpenmcNekDriver::init_mappings()
 
     // Set element->cell and cell->element mappings. Create buffer to store cell
     // handles corresponding to each heat-fluids global element.
-    std::vector<CellHandle> elem_to_cell(heat.n_global_elem());
+    elem_to_cell_.resize(heat.n_global_elem());
 
     auto& neutronics = this->get_neutronics_driver();
     if (neutronics.active()) {
       // Get cell handle corresponding to each element centroid
-      elem_to_cell = neutronics.find(elem_centroids);
+      elem_to_cell_ = neutronics.find(elem_centroids);
 
       // Create a vector of elements for each neutronics cell
-      for (int32_t elem = 0; elem < elem_to_cell.size(); ++elem) {
-        auto cell = elem_to_cell[elem];
+      for (int32_t elem = 0; elem < elem_to_cell_.size(); ++elem) {
+        auto cell = elem_to_cell_[elem];
         cell_to_elems_[cell].push_back(elem);
       }
 
@@ -103,8 +103,7 @@ void OpenmcNekDriver::init_mappings()
     }
 
     // Set element -> cell instance mapping on each Nek rank
-    intranode_comm_.Bcast(elem_to_cell.data(), elem_to_cell.size(), MPI_UINT64_T);
-    elem_to_cell_ = elem_to_cell;
+    intranode_comm_.Bcast(elem_to_cell_.data(), elem_to_cell_.size(), MPI_UINT64_T);
 
     // Broadcast number of cell instances
     intranode_comm_.Bcast(&n_cells_, 1, MPI_INT32_T);


### PR DESCRIPTION
This PR defines an abstract interface for our neutronics drivers that is implemented by `OpenmcDriver`. Most of the abstract method calls rely on passing an opaque "handle" to a cell (defined however the concrete implementation wants to). At initialization time, the `find` method takes a vector of element centroids and returns a vector of cell handles that can then be used later in calls to determine temperatures/densities, etc. With this set of changes, `OpenmcNekDriver` no longer relies on anything specific to `OpenmcDriver` and `NekDriver`.

My next step will be to refactor the `OpenmcHeatDriver` / `SurrogateHeatDriver` classes to match the interfaces define by this PR and #77; that should result in the removal of `OpenmcHeatDriver` altogether, since the logic would be the same as `OpenmcNekDriver` at that point.