### PR TITLE
Scalar and xtensor overloads for Comm::broadcast

### DIFF
--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -190,7 +190,7 @@ void Comm::broadcast(xt::xtensor<T, N>& values) const
 {
   if (this->active()) {
     // First, make sure shape of `values` matches root's
-    auto& s = values.shape();
+    const auto& s = values.shape();
     std::vector<size_t> my_shape(s.begin(), s.end());
     std::vector<size_t> root_shape(my_shape);
 

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -178,13 +178,10 @@ void Comm::broadcast(xt::xtensor<T, N>& values) const
   if (this->active()) {
     // First, make sure shape of `values` matches root's
     auto& s = values.shape();
+    std::vector<size_t> my_shape(s.begin(), s.end());
+    std::vector<size_t> root_shape(my_shape);
 
-    std::vector<int> my_shape;
-    std::copy(s.begin(), s.end(), std::back_inserter(my_shape));
-
-    std::vector<int> root_shape(my_shape);
-    broadcast(root_shape);
-
+    this->broadcast(root_shape);
     if (my_shape != root_shape) {
       values.resize(root_shape);
     }

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -200,7 +200,7 @@ void Comm::broadcast(xt::xtensor<T, N>& values) const
     }
 
     // Next, broadcast size
-    int n = values.size();
+    auto n = values.size();
     this->broadcast(n);
 
     // Finally, broadcast data

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -183,7 +183,7 @@ void Comm::broadcast(xt::xtensor<T, N>& values) const
     std::copy(s.begin(), s.end(), std::back_inserter(my_shape));
 
     std::vector<int> root_shape(my_shape);
-    broadcast<int>(root_shape);
+    broadcast(root_shape);
 
     if (my_shape != root_shape) {
       values.resize(root_shape);

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -151,7 +151,7 @@ bool CoupledDriver::is_converged()
     comm_.message(msg);
   }
 
-  comm_.Bcast(&converged, 1, MPI_CXX_BOOL);
+  comm_.broadcast(converged);
   return converged;
 }
 

--- a/src/message_passing.cpp
+++ b/src/message_passing.cpp
@@ -123,6 +123,12 @@ MPI_Datatype get_mpi_type<double>()
   return MPI_DOUBLE;
 }
 
+template<>
+MPI_Datatype get_mpi_type<bool>()
+{
+  return MPI_CXX_BOOL;
+}
+
 // Traits for mapping plain types to corresponding MPI types (user defined)
 template<>
 MPI_Datatype get_mpi_type<Position>()

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -85,7 +85,7 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
 
   // Broadcast number of realizations
   // TODO: Change OpenMC so that it's correct on all ranks
-  comm_.Bcast(&m, 1, MPI_INT);
+  comm_.broadcast(m);
 
   // Determine energy production in each material
   auto mean_value = xt::view(tally_->results_, xt::all(), 0, openmc::RESULT_SUM);

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -108,7 +108,7 @@ void OpenmcNekDriver::init_mappings()
     intranode_comm_.broadcast(elem_to_cell_);
 
     // Broadcast number of cell instances
-    intranode_comm_.Bcast(&n_cells_, 1, MPI_INT32_T);
+    intranode_comm_.broadcast(n_cells_);
   }
 }
 

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -289,7 +289,7 @@ void OpenmcNekDriver::set_heat_source()
 {
   // OpenMC has heat source on each of its ranks. We need to make heat
   // source available on each Nek rank.
-  intranode_comm_.Bcast(heat_source_.data(), n_cells_, MPI_DOUBLE);
+  intranode_comm_.broadcast(heat_source_);
 
   auto& heat = this->get_heat_driver();
   if (heat.active()) {
@@ -318,7 +318,7 @@ void OpenmcNekDriver::set_temperature()
     auto& neutronics = this->get_neutronics_driver();
     if (neutronics.active()) {
       // Broadcast global_element_temperatures onto all the OpenMC procs
-      neutronics.comm_.Bcast(temperatures_.data(), temperatures_.size(), MPI_DOUBLE);
+      neutronics.comm_.broadcast(temperatures_);
 
       // For each OpenMC cell instance, volume average temperatures and set
       for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
@@ -353,7 +353,7 @@ void OpenmcNekDriver::set_density()
     // TODO: This won't work if the Nek/OpenMC communicators are disjoint
     auto& neutronics = this->get_neutronics_driver();
     if (neutronics.active()) {
-      neutronics.comm_.Bcast(densities_.data(), densities_.size(), MPI_DOUBLE);
+      neutronics.comm_.broadcast(densities_);
 
       // For each OpenMC cell instance in a fluid cell, volume average the
       // densities and set


### PR DESCRIPTION
This PR adds overloads to `Comm::broadcast` so it can handle a scalar or `xtensor`.  

For an `xtensor`, the non-root's destination buffer is resized according to the root send buffer's shape (and not simply according to its size).  