### PR TITLE
MPI_Comm --> Comm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,9 @@ target_link_libraries(heat_xfer PUBLIC iapws)
 set(SOURCES
     src/driver.cpp
     src/coupled_driver.cpp
+    src/comm_split.cpp
     src/surrogate_heat_driver.cpp
-    src/message_passing.cpp
+    src/mpi_types.cpp
     src/openmc_driver.cpp
     src/cell_instance.cpp
     src/openmc_nek_driver.cpp

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -3,7 +3,7 @@
 #ifndef ENRICO_COMM_H
 #define ENRICO_COMM_H
 
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "xtensor/xtensor.hpp"
 
 #include <mpi.h>

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -32,6 +32,19 @@ public:
     }
   }
 
+  //! Frees the underlying MPI Communicator and nullifies/zeroes the group, rank, and size
+  //! \return Error value
+  int free()
+  {
+    auto ierr = MPI_Comm_free(&comm);
+    if (ierr == MPI_SUCCESS) {
+      group = MPI_GROUP_NULL;
+      rank = MPI_PROC_NULL;
+      size = 0;
+    }
+    return ierr;
+  };
+
   //! Queries whether the communicator is active
   //! \return True if the communicator is not MPI_COMM_NULL
   bool active() const { return comm != MPI_COMM_NULL; }

--- a/include/enrico/comm_split.h
+++ b/include/enrico/comm_split.h
@@ -1,7 +1,7 @@
 #ifndef ENRICO_COMM_SPLIT_H
 #define ENRICO_COMM_SPLIT_H
 
-#include <mpi.h>
+#include "comm.h"
 
 namespace enrico {
 
@@ -35,10 +35,10 @@ namespace enrico {
 //! communicator (sub_comm) \param[out] sub_comm A new internode comm with the desired
 //! number of procs per node \param[out] intranode_comm A new intranode comm wil procs in
 //! the same node
-void get_node_comms(MPI_Comm super_comm,
+void get_node_comms(Comm super_comm,
                     int procs_per_node,
-                    MPI_Comm* sub_comm,
-                    MPI_Comm* intranode_comm);
+                    Comm& sub_comm,
+                    Comm& intranode_comm);
 
 }
 

--- a/include/enrico/comm_split.h
+++ b/include/enrico/comm_split.h
@@ -1,22 +1,9 @@
-//! \file message_passing.h
-//! Utility functions for constucting MPI communicators
-#ifndef ENRICO_MESSAGE_PASSING_H
-#define ENRICO_MESSAGE_PASSING_H
+#ifndef ENRICO_COMM_SPLIT_H
+#define ENRICO_COMM_SPLIT_H
 
 #include <mpi.h>
 
-//! The ENRICO namespace
 namespace enrico {
-
-//==============================================================================
-// Global variables
-//==============================================================================
-
-extern MPI_Datatype position_mpi_datatype;
-
-//==============================================================================
-// Functions
-//==============================================================================
 
 //! Splits a given MPI comunicator into new inter- and intra-node communicators
 //!
@@ -53,16 +40,6 @@ void get_node_comms(MPI_Comm super_comm,
                     MPI_Comm* sub_comm,
                     MPI_Comm* intranode_comm);
 
-//! Create MPI datatype for Position struct
-void init_mpi_datatypes();
+}
 
-//! Free any MPI datatypes
-void free_mpi_datatypes();
-
-//! Map types to corresponding MPI datatypes
-template<typename T>
-MPI_Datatype get_mpi_type();
-
-} // namespace enrico
-
-#endif // ENRICO_MESSAGE_PASSING_H
+#endif // ENRICO_COMM_SPLIT_H

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -23,7 +23,7 @@ public:
   //!
   //! \param comm The MPI communicator used for the coupled driver
   //! \param node XML node containing settings
-  explicit CoupledDriver(MPI_Comm comm, pugi::xml_node node);
+  explicit CoupledDriver(Comm comm, pugi::xml_node node);
 
   ~CoupledDriver() {}
 

--- a/include/enrico/driver.h
+++ b/include/enrico/driver.h
@@ -17,7 +17,7 @@ class Driver {
 public:
   //! Initializes the solver with the given MPI communicator.
   //! \param comm An existing MPI communicator used to initialize the solver
-  explicit Driver(MPI_Comm comm)
+  explicit Driver(Comm comm)
     : comm_(comm)
   {}
 

--- a/include/enrico/driver.h
+++ b/include/enrico/driver.h
@@ -4,7 +4,7 @@
 #define ENRICO_DRIVERS_H
 
 #include "enrico/comm.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 
 #include <mpi.h>
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -15,7 +15,7 @@ namespace enrico {
 //! Base class for driver that controls a heat-fluids solve
 class HeatFluidsDriver : public Driver {
 public:
-  explicit HeatFluidsDriver(MPI_Comm comm, double pressure_bc);
+  explicit HeatFluidsDriver(Comm comm, double pressure_bc);
 
   virtual ~HeatFluidsDriver() = default;
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -5,7 +5,7 @@
 
 #include "enrico/driver.h"
 #include "enrico/geom.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "xtensor/xtensor.hpp"
 
 #include <cstddef> // for size_t

--- a/include/enrico/mpi_types.h
+++ b/include/enrico/mpi_types.h
@@ -1,0 +1,33 @@
+//! \file message_passing.h
+//! Utility functions for constucting MPI communicators
+#ifndef ENRICO_MPI_TYPES_H
+#define ENRICO_MPI_TYPES_H
+
+#include <mpi.h>
+
+//! The ENRICO namespace
+namespace enrico {
+
+//==============================================================================
+// Global variables
+//==============================================================================
+
+extern MPI_Datatype position_mpi_datatype;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+//! Create MPI datatype for Position struct
+void init_mpi_datatypes();
+
+//! Free any MPI datatypes
+void free_mpi_datatypes();
+
+//! Map types to corresponding MPI datatypes
+template<typename T>
+MPI_Datatype get_mpi_type();
+
+} // namespace enrico
+
+#endif // ENRICO_MPI_TYPES_H

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -24,7 +24,7 @@ public:
   //! NekDriver.
   //!
   //! \param comm  The MPI communicator used to initialze Nek5000
-  explicit NekDriver(MPI_Comm comm, double pressure_bc, pugi::xml_node xml_root);
+  explicit NekDriver(Comm comm, double pressure_bc, pugi::xml_node xml_root);
 
   //! Finalizes Nek5000.
   //!

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -5,7 +5,7 @@
 
 #include "enrico/driver.h"
 #include "enrico/geom.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 
 #include <gsl/gsl>
 #include <xtensor/xtensor.hpp>

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -19,7 +19,7 @@ using CellHandle = gsl::index;
 //! Base class for driver that controls a neutronics solve
 class NeutronicsDriver : public Driver {
 public:
-  explicit NeutronicsDriver(MPI_Comm comm)
+  explicit NeutronicsDriver(Comm comm)
     : Driver(comm)
   {}
 

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -22,7 +22,7 @@ class OpenmcDriver : public NeutronicsDriver {
 public:
   //! One-time initalization of OpenMC and member variables
   //! \param comm An existing MPI communicator used to inialize OpenMC
-  explicit OpenmcDriver(MPI_Comm comm);
+  explicit OpenmcDriver(Comm comm);
 
   //! One-time finalization of OpenMC
   ~OpenmcDriver();

--- a/include/enrico/openmc_heat_driver.h
+++ b/include/enrico/openmc_heat_driver.h
@@ -22,7 +22,7 @@ public:
   //!
   //! \param comm  The MPI communicator used for the coupled driver
   //! \param node  XML node containing settings
-  explicit OpenmcHeatDriver(MPI_Comm comm, pugi::xml_node node);
+  explicit OpenmcHeatDriver(Comm comm, pugi::xml_node node);
 
   //! Whether the calling rank has access to global coupling fields. Because OpenMC
   //! and the surrogate driver share the same communicator, and the surrogate driver does not

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -5,7 +5,7 @@
 
 #include "enrico/coupled_driver.h"
 #include "enrico/heat_fluids_driver.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/neutronics_driver.h"
 
 #include <mpi.h>

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -26,7 +26,7 @@ public:
   //!
   //! \param comm The MPI communicator used for the coupled driver
   //! \param node XML node containing settings
-  explicit OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node);
+  explicit OpenmcNekDriver(Comm comm, pugi::xml_node node);
 
   //! Whether the calling rank has access to global coupling fields. Because the OpenMC
   //! and Nek communicators are assumed to overlap (though they are not the same), and

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -151,7 +151,7 @@ public:
   //!
   //! \param comm  The MPI communicator used to initialze the surrogate
   //! \param node  XML node containing settings for surrogate
-  explicit SurrogateHeatDriver(MPI_Comm comm, double pressure_bc, pugi::xml_node node);
+  explicit SurrogateHeatDriver(Comm comm, double pressure_bc, pugi::xml_node node);
 
   //! Verbosity options for printing simulation results
   enum class verbose { NONE, LOW, HIGH };

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -8,7 +8,7 @@
 
 #include "Assembly_Model.h"
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/nek_driver.h"
 #include "nek5000/core/nek_interface.h"
 #include "shift_driver.h"

--- a/src/comm_split.cpp
+++ b/src/comm_split.cpp
@@ -1,0 +1,31 @@
+#include "enrico/comm_split.h"
+
+namespace enrico {
+
+void get_node_comms(MPI_Comm super_comm,
+                    int procs_per_node,
+                    MPI_Comm* sub_comm,
+                    MPI_Comm* intranode_comm)
+{
+
+  // super_comm_rank is used as the "key" to retain ordering in the comm splits.
+  // This can allow the sub_comm to retain some intent from the super_comm's proc layout
+  int super_comm_rank;
+  MPI_Comm_rank(super_comm, &super_comm_rank);
+
+  // intranode_comm is an intermediate object.  It is only used to get an
+  // intranode_comm_rank, which is used as the "color" in the final comm split.
+  MPI_Comm_split_type(
+    super_comm, MPI_COMM_TYPE_SHARED, super_comm_rank, MPI_INFO_NULL, intranode_comm);
+  int intranode_comm_rank;
+  MPI_Comm_rank(*intranode_comm, &intranode_comm_rank);
+
+  // Finally, split the specified number of procs_per_node from the super_comm
+  // We only want the comm where color == 0.  The second comm is destroyed.
+  int color = intranode_comm_rank < procs_per_node ? 0 : 1;
+  MPI_Comm_split(super_comm, color, super_comm_rank, sub_comm);
+  if (color != 0)
+    MPI_Comm_free(sub_comm);
+}
+
+}

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -7,7 +7,7 @@
 
 namespace enrico {
 
-CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
+CoupledDriver::CoupledDriver(Comm comm, pugi::xml_node node)
   : comm_(comm)
 {
   // get required coupling parameters

--- a/src/heat_fluids_driver.cpp
+++ b/src/heat_fluids_driver.cpp
@@ -5,7 +5,7 @@
 
 namespace enrico {
 
-HeatFluidsDriver::HeatFluidsDriver(MPI_Comm comm, double pressure_bc)
+HeatFluidsDriver::HeatFluidsDriver(Comm comm, double pressure_bc)
   : Driver(comm)
   , pressure_bc_(pressure_bc)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "pugixml.hpp"
 #include <mpi.h>
 
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/openmc_heat_driver.h"
 #include "enrico/openmc_nek_driver.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include "pugixml.hpp"
 #include <mpi.h>
 
+#include "enrico/comm.h"
 #include "enrico/mpi_types.h"
 #include "enrico/openmc_heat_driver.h"
 #include "enrico/openmc_nek_driver.h"
@@ -12,6 +13,7 @@ int main(int argc, char* argv[])
   // Initialize MPI
   MPI_Init(&argc, &argv);
   enrico::init_mpi_datatypes();
+  enrico::Comm comm_world(MPI_COMM_WORLD);
 
   // Define enums for selecting drivers
   enum class Transport { OpenMC, Shift, Surrogate };
@@ -54,12 +56,12 @@ int main(int argc, char* argv[])
   case Transport::OpenMC:
     switch (driver_heatfluids) {
     case HeatFluids::Nek5000: {
-      enrico::OpenmcNekDriver driver{MPI_COMM_WORLD, root};
+      enrico::OpenmcNekDriver driver{comm_world, root};
       driver.execute();
     } break;
     case HeatFluids::Surrogate: {
       // Pass XML node for reading settings
-      enrico::OpenmcHeatDriver driver{MPI_COMM_WORLD, root};
+      enrico::OpenmcHeatDriver driver{comm_world, root};
       driver.execute();
     } break;
     }

--- a/src/mpi_types.cpp
+++ b/src/mpi_types.cpp
@@ -1,4 +1,4 @@
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 
 #include "enrico/geom.h"
 
@@ -15,32 +15,6 @@ MPI_Datatype position_mpi_datatype{MPI_DATATYPE_NULL};
 //==============================================================================
 // Functions
 //==============================================================================
-
-void get_node_comms(MPI_Comm super_comm,
-                    int procs_per_node,
-                    MPI_Comm* sub_comm,
-                    MPI_Comm* intranode_comm)
-{
-
-  // super_comm_rank is used as the "key" to retain ordering in the comm splits.
-  // This can allow the sub_comm to retain some intent from the super_comm's proc layout
-  int super_comm_rank;
-  MPI_Comm_rank(super_comm, &super_comm_rank);
-
-  // intranode_comm is an intermediate object.  It is only used to get an
-  // intranode_comm_rank, which is used as the "color" in the final comm split.
-  MPI_Comm_split_type(
-    super_comm, MPI_COMM_TYPE_SHARED, super_comm_rank, MPI_INFO_NULL, intranode_comm);
-  int intranode_comm_rank;
-  MPI_Comm_rank(*intranode_comm, &intranode_comm_rank);
-
-  // Finally, split the specified number of procs_per_node from the super_comm
-  // We only want the comm where color == 0.  The second comm is destroyed.
-  int color = intranode_comm_rank < procs_per_node ? 0 : 1;
-  MPI_Comm_split(super_comm, color, super_comm_rank, sub_comm);
-  if (color != 0)
-    MPI_Comm_free(sub_comm);
-}
 
 void init_mpi_datatypes()
 {

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -14,11 +14,11 @@
 
 namespace enrico {
 
-NekDriver::NekDriver(MPI_Comm comm, double pressure_bc, pugi::xml_node node)
+NekDriver::NekDriver(Comm comm, double pressure_bc, pugi::xml_node xml_root)
   : HeatFluidsDriver(comm, pressure_bc)
 {
   if (active()) {
-    casename_ = node.child_value("casename");
+    casename_ = xml_root.child_value("casename");
     if (comm_.rank == 0) {
       init_session_name();
     }

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -19,7 +19,7 @@
 
 namespace enrico {
 
-OpenmcDriver::OpenmcDriver(MPI_Comm comm)
+OpenmcDriver::OpenmcDriver(Comm comm)
   : NeutronicsDriver(comm)
 {
   if (active()) {

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -12,7 +12,7 @@
 
 namespace enrico {
 
-OpenmcHeatDriver::OpenmcHeatDriver(MPI_Comm comm, pugi::xml_node node)
+OpenmcHeatDriver::OpenmcHeatDriver(Comm comm, pugi::xml_node node)
   : CoupledDriver(comm, node)
 {
   // Initialize OpenMC and surrogate heat drivers

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -1,7 +1,7 @@
 #include "enrico/openmc_heat_driver.h"
 
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "gsl/gsl"
 #include "openmc/constants.h"
 #include "openmc/tallies/filter_cell_instance.h"

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -22,7 +22,7 @@ namespace enrico {
 
 using gsl::index;
 
-OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
+OpenmcNekDriver::OpenmcNekDriver(Comm comm, pugi::xml_node node)
   : CoupledDriver{comm, node}
 {
   // Get parameters from enrico.xml
@@ -34,13 +34,8 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
   Expects(openmc_procs_per_node_ > 0);
 
   // Create communicator for OpenMC with requested processes per node
-  MPI_Comm openmc_comm;
-  MPI_Comm intranode_comm;
-  enrico::get_node_comms(
-    comm_.comm, openmc_procs_per_node_, &openmc_comm, &intranode_comm);
-
-  // Set intranode communicator
-  intranode_comm_ = Comm(intranode_comm);
+  Comm openmc_comm;
+  enrico::get_node_comms(comm, openmc_procs_per_node_, openmc_comm, intranode_comm_);
 
   // Instantiate OpenMC and Nek drivers
   neutronics_driver_ = std::make_unique<OpenmcDriver>(openmc_comm);

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -1,8 +1,9 @@
 #include "enrico/openmc_nek_driver.h"
 
+#include "enrico/comm_split.h"
 #include "enrico/const.h"
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/nek_driver.h"
 #include "enrico/openmc_driver.h"
 

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/nek_driver.h"
 #include "nek5000/core/nek_interface.h"
 #include "smrt/shift_nek_driver.h"

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -16,7 +16,7 @@ namespace enrico {
 int ChannelFactory::index_ = 0;
 int RodFactory::index_ = 0;
 
-SurrogateHeatDriver::SurrogateHeatDriver(MPI_Comm comm,
+SurrogateHeatDriver::SurrogateHeatDriver(Comm comm,
                                          double pressure_bc,
                                          pugi::xml_node node)
   : HeatFluidsDriver(comm, pressure_bc)

--- a/tests/singlerod/short/test_nek5000.cpp
+++ b/tests/singlerod/short/test_nek5000.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* argv[])
   auto root = doc.document_element();
 
   {
-    enrico::NekDriver test_driver(MPI_COMM_WORLD,
+    enrico::NekDriver test_driver(enrico::Comm(MPI_COMM_WORLD),
                                   root.child("pressure_bc").text().as_double(),
                                   root.child("nek5000"));
     test_driver.init_step();

--- a/tests/singlerod/short/test_openmc.cpp
+++ b/tests/singlerod/short/test_openmc.cpp
@@ -5,7 +5,7 @@ int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
 
   {
-    enrico::OpenmcDriver test_driver(MPI_COMM_WORLD);
+    enrico::OpenmcDriver test_driver(enrico::Comm(MPI_COMM_WORLD));
     test_driver.init_step();
     test_driver.solve_step();
     test_driver.write_step(0, 0);

--- a/tests/unit/test_surrogate_th.cpp
+++ b/tests/unit/test_surrogate_th.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Verify construction of surrogate thermal-hydraulics driver", "[constr
   auto node = root.child("heat_surrogate");
 
   double outlet_pressure = 101325.0;
-  enrico::SurrogateHeatDriver driver(MPI_COMM_NULL, outlet_pressure, node);
+  enrico::SurrogateHeatDriver driver(enrico::Comm(MPI_COMM_NULL), outlet_pressure, node);
 
   SECTION("Verify XML input file reading") {
     CHECK(driver.clad_inner_radius() == Approx(0.414));


### PR DESCRIPTION
Here, I've used ENRICO's `Comm` class to replace most usages of `MPI_Comm`.  The main motivation was to make comm splits clearer, such as the splits in `get_node_comms`.  It should make the upcoming comm split operations (such as the disjoint comms) clearer as well.  

Other notes:
* `Comm` has a `free()` member function
* Declarations from `message_passing.h` have been split into `comm_split.h` and `mpi_types.h` (and likewise for the definitions).  This was done primarily to solve some circular dependencies that I couldn't resolve with forward declarations.  