### PR TITLE
Comm split func

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,9 @@ target_link_libraries(heat_xfer PUBLIC iapws)
 set(SOURCES
     src/driver.cpp
     src/coupled_driver.cpp
+    src/comm_split.cpp
     src/surrogate_heat_driver.cpp
-    src/message_passing.cpp
+    src/mpi_types.cpp
     src/openmc_driver.cpp
     src/cell_instance.cpp
     src/openmc_nek_driver.cpp

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -3,7 +3,7 @@
 #ifndef ENRICO_COMM_H
 #define ENRICO_COMM_H
 
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "xtensor/xtensor.hpp"
 
 #include <mpi.h>

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -32,6 +32,19 @@ public:
     }
   }
 
+  //! Frees the underlying MPI Communicator and nullifies/zeroes the group, rank, and size
+  //! \return Error value
+  int free()
+  {
+    auto ierr = MPI_Comm_free(&comm);
+    if (ierr == MPI_SUCCESS) {
+      group = MPI_GROUP_NULL;
+      rank = MPI_PROC_NULL;
+      size = 0;
+    }
+    return ierr;
+  };
+
   //! Queries whether the communicator is active
   //! \return True if the communicator is not MPI_COMM_NULL
   bool active() const { return comm != MPI_COMM_NULL; }

--- a/include/enrico/comm_split.h
+++ b/include/enrico/comm_split.h
@@ -1,6 +1,8 @@
 #ifndef ENRICO_COMM_SPLIT_H
 #define ENRICO_COMM_SPLIT_H
 
+#include "comm.h"
+
 #include <mpi.h>
 
 namespace enrico {
@@ -35,10 +37,10 @@ namespace enrico {
 //! communicator (sub_comm) \param[out] sub_comm A new internode comm with the desired
 //! number of procs per node \param[out] intranode_comm A new intranode comm wil procs in
 //! the same node
-void get_node_comms(MPI_Comm super_comm,
+void get_node_comms(Comm super_comm,
                     int procs_per_node,
-                    MPI_Comm* sub_comm,
-                    MPI_Comm* intranode_comm);
+                    Comm& sub_comm,
+                    Comm& intranode_comm);
 
 }
 

--- a/include/enrico/comm_split.h
+++ b/include/enrico/comm_split.h
@@ -1,22 +1,9 @@
-//! \file message_passing.h
-//! Utility functions for constucting MPI communicators
-#ifndef ENRICO_MESSAGE_PASSING_H
-#define ENRICO_MESSAGE_PASSING_H
+#ifndef ENRICO_COMM_SPLIT_H
+#define ENRICO_COMM_SPLIT_H
 
 #include <mpi.h>
 
-//! The ENRICO namespace
 namespace enrico {
-
-//==============================================================================
-// Global variables
-//==============================================================================
-
-extern MPI_Datatype position_mpi_datatype;
-
-//==============================================================================
-// Functions
-//==============================================================================
 
 //! Splits a given MPI comunicator into new inter- and intra-node communicators
 //!
@@ -53,16 +40,6 @@ void get_node_comms(MPI_Comm super_comm,
                     MPI_Comm* sub_comm,
                     MPI_Comm* intranode_comm);
 
-//! Create MPI datatype for Position struct
-void init_mpi_datatypes();
+}
 
-//! Free any MPI datatypes
-void free_mpi_datatypes();
-
-//! Map types to corresponding MPI datatypes
-template<typename T>
-MPI_Datatype get_mpi_type();
-
-} // namespace enrico
-
-#endif // ENRICO_MESSAGE_PASSING_H
+#endif // ENRICO_COMM_SPLIT_H

--- a/include/enrico/driver.h
+++ b/include/enrico/driver.h
@@ -4,7 +4,7 @@
 #define ENRICO_DRIVERS_H
 
 #include "enrico/comm.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 
 #include <mpi.h>
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -5,7 +5,7 @@
 
 #include "enrico/driver.h"
 #include "enrico/geom.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "xtensor/xtensor.hpp"
 
 #include <cstddef> // for size_t

--- a/include/enrico/mpi_types.h
+++ b/include/enrico/mpi_types.h
@@ -1,0 +1,33 @@
+//! \file message_passing.h
+//! Utility functions for constucting MPI communicators
+#ifndef ENRICO_MPI_TYPES_H
+#define ENRICO_MPI_TYPES_H
+
+#include <mpi.h>
+
+//! The ENRICO namespace
+namespace enrico {
+
+//==============================================================================
+// Global variables
+//==============================================================================
+
+extern MPI_Datatype position_mpi_datatype;
+
+//==============================================================================
+// Functions
+//==============================================================================
+
+//! Create MPI datatype for Position struct
+void init_mpi_datatypes();
+
+//! Free any MPI datatypes
+void free_mpi_datatypes();
+
+//! Map types to corresponding MPI datatypes
+template<typename T>
+MPI_Datatype get_mpi_type();
+
+} // namespace enrico
+
+#endif // ENRICO_MPI_TYPES_H

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -5,7 +5,7 @@
 
 #include "enrico/driver.h"
 #include "enrico/geom.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 
 #include <gsl/gsl>
 #include <xtensor/xtensor.hpp>

--- a/include/enrico/openmc_nek_driver.h
+++ b/include/enrico/openmc_nek_driver.h
@@ -5,7 +5,7 @@
 
 #include "enrico/coupled_driver.h"
 #include "enrico/heat_fluids_driver.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/neutronics_driver.h"
 
 #include <mpi.h>

--- a/include/smrt/shift_nek_driver.h
+++ b/include/smrt/shift_nek_driver.h
@@ -8,7 +8,7 @@
 
 #include "Assembly_Model.h"
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/nek_driver.h"
 #include "nek5000/core/nek_interface.h"
 #include "shift_driver.h"

--- a/src/comm_split.cpp
+++ b/src/comm_split.cpp
@@ -1,0 +1,31 @@
+#include "enrico/comm_split.h"
+
+namespace enrico {
+
+void get_node_comms(MPI_Comm super_comm,
+                    int procs_per_node,
+                    MPI_Comm* sub_comm,
+                    MPI_Comm* intranode_comm)
+{
+
+  // super_comm_rank is used as the "key" to retain ordering in the comm splits.
+  // This can allow the sub_comm to retain some intent from the super_comm's proc layout
+  int super_comm_rank;
+  MPI_Comm_rank(super_comm, &super_comm_rank);
+
+  // intranode_comm is an intermediate object.  It is only used to get an
+  // intranode_comm_rank, which is used as the "color" in the final comm split.
+  MPI_Comm_split_type(
+    super_comm, MPI_COMM_TYPE_SHARED, super_comm_rank, MPI_INFO_NULL, intranode_comm);
+  int intranode_comm_rank;
+  MPI_Comm_rank(*intranode_comm, &intranode_comm_rank);
+
+  // Finally, split the specified number of procs_per_node from the super_comm
+  // We only want the comm where color == 0.  The second comm is destroyed.
+  int color = intranode_comm_rank < procs_per_node ? 0 : 1;
+  MPI_Comm_split(super_comm, color, super_comm_rank, sub_comm);
+  if (color != 0)
+    MPI_Comm_free(sub_comm);
+}
+
+}

--- a/src/comm_split.cpp
+++ b/src/comm_split.cpp
@@ -2,30 +2,26 @@
 
 namespace enrico {
 
-void get_node_comms(MPI_Comm super_comm,
+void get_node_comms(Comm super_comm,
                     int procs_per_node,
-                    MPI_Comm* sub_comm,
-                    MPI_Comm* intranode_comm)
+                    Comm& sub_comm,
+                    Comm& intranode_comm)
 {
-
-  // super_comm_rank is used as the "key" to retain ordering in the comm splits.
-  // This can allow the sub_comm to retain some intent from the super_comm's proc layout
-  int super_comm_rank;
-  MPI_Comm_rank(super_comm, &super_comm_rank);
-
-  // intranode_comm is an intermediate object.  It is only used to get an
-  // intranode_comm_rank, which is used as the "color" in the final comm split.
+  // Each intranode_comm contains all ranks in a given shared memory region (usually node)
+  MPI_Comm icomm;
   MPI_Comm_split_type(
-    super_comm, MPI_COMM_TYPE_SHARED, super_comm_rank, MPI_INFO_NULL, intranode_comm);
-  int intranode_comm_rank;
-  MPI_Comm_rank(*intranode_comm, &intranode_comm_rank);
+    super_comm.comm, MPI_COMM_TYPE_SHARED, super_comm.rank, MPI_INFO_NULL, &icomm);
+  intranode_comm = Comm(icomm);
 
-  // Finally, split the specified number of procs_per_node from the super_comm
+  // Split the specified number of procs_per_node from the super_comm
   // We only want the comm where color == 0.  The second comm is destroyed.
-  int color = intranode_comm_rank < procs_per_node ? 0 : 1;
-  MPI_Comm_split(super_comm, color, super_comm_rank, sub_comm);
-  if (color != 0)
-    MPI_Comm_free(sub_comm);
+  int color = intranode_comm.rank < procs_per_node ? 0 : 1;
+  MPI_Comm scomm;
+  MPI_Comm_split(super_comm.comm, color, super_comm.rank, &scomm);
+  sub_comm = Comm(scomm);
+  if (color != 0) {
+    sub_comm.free();
+  }
 }
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "pugixml.hpp"
 #include <mpi.h>
 
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/openmc_heat_driver.h"
 #include "enrico/openmc_nek_driver.h"
 

--- a/src/mpi_types.cpp
+++ b/src/mpi_types.cpp
@@ -1,4 +1,4 @@
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 
 #include "enrico/geom.h"
 
@@ -15,32 +15,6 @@ MPI_Datatype position_mpi_datatype{MPI_DATATYPE_NULL};
 //==============================================================================
 // Functions
 //==============================================================================
-
-void get_node_comms(MPI_Comm super_comm,
-                    int procs_per_node,
-                    MPI_Comm* sub_comm,
-                    MPI_Comm* intranode_comm)
-{
-
-  // super_comm_rank is used as the "key" to retain ordering in the comm splits.
-  // This can allow the sub_comm to retain some intent from the super_comm's proc layout
-  int super_comm_rank;
-  MPI_Comm_rank(super_comm, &super_comm_rank);
-
-  // intranode_comm is an intermediate object.  It is only used to get an
-  // intranode_comm_rank, which is used as the "color" in the final comm split.
-  MPI_Comm_split_type(
-    super_comm, MPI_COMM_TYPE_SHARED, super_comm_rank, MPI_INFO_NULL, intranode_comm);
-  int intranode_comm_rank;
-  MPI_Comm_rank(*intranode_comm, &intranode_comm_rank);
-
-  // Finally, split the specified number of procs_per_node from the super_comm
-  // We only want the comm where color == 0.  The second comm is destroyed.
-  int color = intranode_comm_rank < procs_per_node ? 0 : 1;
-  MPI_Comm_split(super_comm, color, super_comm_rank, sub_comm);
-  if (color != 0)
-    MPI_Comm_free(sub_comm);
-}
 
 void init_mpi_datatypes()
 {

--- a/src/openmc_heat_driver.cpp
+++ b/src/openmc_heat_driver.cpp
@@ -1,7 +1,7 @@
 #include "enrico/openmc_heat_driver.h"
 
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "gsl/gsl"
 #include "openmc/constants.h"
 #include "openmc/tallies/filter_cell_instance.h"

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -34,16 +34,11 @@ OpenmcNekDriver::OpenmcNekDriver(MPI_Comm comm, pugi::xml_node node)
   Expects(openmc_procs_per_node_ > 0);
 
   // Create communicator for OpenMC with requested processes per node
-  MPI_Comm openmc_comm;
-  MPI_Comm intranode_comm;
-  enrico::get_node_comms(
-    comm_.comm, openmc_procs_per_node_, &openmc_comm, &intranode_comm);
-
-  // Set intranode communicator
-  intranode_comm_ = Comm(intranode_comm);
+  Comm openmc_comm;
+  enrico::get_node_comms(comm_, openmc_procs_per_node_, openmc_comm, intranode_comm_);
 
   // Instantiate OpenMC and Nek drivers
-  neutronics_driver_ = std::make_unique<OpenmcDriver>(openmc_comm);
+  neutronics_driver_ = std::make_unique<OpenmcDriver>(openmc_comm.comm);
   heat_fluids_driver_ = std::make_unique<NekDriver>(comm, pressure_bc, nek_node);
 
   init_mappings();

--- a/src/openmc_nek_driver.cpp
+++ b/src/openmc_nek_driver.cpp
@@ -1,8 +1,9 @@
 #include "enrico/openmc_nek_driver.h"
 
+#include "enrico/comm_split.h"
 #include "enrico/const.h"
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/nek_driver.h"
 #include "enrico/openmc_driver.h"
 

--- a/src/smrt/shift_nek_driver.cpp
+++ b/src/smrt/shift_nek_driver.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 #include "enrico/error.h"
-#include "enrico/message_passing.h"
+#include "enrico/mpi_types.h"
 #include "enrico/nek_driver.h"
 #include "nek5000/core/nek_interface.h"
 #include "smrt/shift_nek_driver.h"


### PR DESCRIPTION
This replaces #81 with a more limited set of changes:

* `Comm` has a `free()` member function
* Declarations from `message_passing.h` have been split into `comm_split.h` and `mpi_types.h` (and likewise for the definitions).  This  solved circular dependencies that I couldn't resolve with forward declarations.  
* `get_node_comms` uses `Comm`s for clarity.
