### PR TITLE
Disjoint Communicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,9 @@ target_link_libraries(enrico PUBLIC libenrico)
 # =============================================================================
 add_executable(comm_split_demo tests/comm_split_demo/main.cpp)
 
+add_executable(disjoint_comm_demo tests/disjoint_comm_demo/main.cpp)
+target_link_libraries(disjoint_comm_demo PUBLIC libenrico)
+
 add_executable(test_nek5000_singlerod tests/singlerod/short/test_nek5000.cpp)
 target_link_libraries(test_nek5000_singlerod PUBLIC libenrico)
 
@@ -128,7 +131,7 @@ target_link_libraries(test_openmc_singlerod PUBLIC libenrico)
 
 # Ensure C++14 standard is used
 set_target_properties(
-    enrico libenrico
+        enrico libenrico
     comm_split_demo
     heat_xfer
     iapws

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,9 @@ target_link_libraries(test_nek5000_singlerod PUBLIC libenrico)
 add_executable(test_openmc_singlerod tests/singlerod/short/test_openmc.cpp)
 target_link_libraries(test_openmc_singlerod PUBLIC libenrico)
 
+add_executable(disjoint_bcast_debug tests/disjoint_bcast_debug/main.cpp)
+target_link_libraries(disjoint_bcast_debug PUBLIC libenrico)
+
 # Ensure C++14 standard is used
 set_target_properties(
         enrico libenrico

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,12 +132,13 @@ target_link_libraries(test_openmc_singlerod PUBLIC libenrico)
 # Ensure C++14 standard is used
 set_target_properties(
         enrico libenrico
-    comm_split_demo
-    heat_xfer
-    iapws
-    test_nek5000_singlerod
-    test_openmc_singlerod
-    PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+        comm_split_demo
+        disjoint_comm_demo
+        heat_xfer
+        iapws
+        test_nek5000_singlerod
+        test_openmc_singlerod
+        PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
 
 if (SCALE_FOUND)
   add_executable(test_shift_singlerod tests/singlerod/short/test_shift_coupled.cpp)

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -89,7 +89,7 @@ public:
   void broadcast(xt::xtensor<T, N>& values) const;
 
   //! Send a scalar from one rank to another
-  //! \param value Value to broadcast (significant at source rank)
+  //! \param value Value to send (significant at source rank)
   //! \param dest Destination rank
   //! \param source Source rank
   template<typename T>

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -104,7 +104,7 @@ public:
   void sendrecv_replace(std::vector<T>& values, int dest, int source) const;
 
   //! Send an xtensor from one rank to another, possibly resizing it at destination
-  //! \param values Values to broadcast (significant at source rank)
+  //! \param values Values to send (significant at source rank)
   //! \param dest Destination rank
   //! \param source Source rank
   template<typename T, size_t N>

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -97,7 +97,7 @@ public:
   sendrecv_replace(T& value, int dest, int source) const;
 
   //! Send a vector from one rank to another, possibly resizing it at destination
-  //! \param values Values to broadcast (significant at source rank)
+  //! \param values Values to send (significant at source rank)
   //! \param dest Destination rank
   //! \param source Source rank
   template<typename T>

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -207,8 +207,17 @@ template<typename T>
 std::enable_if_t<std::is_scalar<std::decay_t<T>>::value>
 Comm::sendrecv_replace(T& value, int dest, int source) const
 {
-  MPI_Sendrecv_replace(
-    &value, 1, get_mpi_type<T>(), dest, 0, source, MPI_ANY_TAG, comm, MPI_STATUS_IGNORE);
+  if (rank == dest || rank == source) {
+    MPI_Sendrecv_replace(&value,
+                         1,
+                         get_mpi_type<T>(),
+                         dest,
+                         0,
+                         source,
+                         MPI_ANY_TAG,
+                         comm,
+                         MPI_STATUS_IGNORE);
+  }
 };
 
 template<typename T>
@@ -222,15 +231,17 @@ void Comm::sendrecv_replace(std::vector<T>& values, int dest, int source) const
     values.resize(n);
   }
   // Send the vector
-  MPI_Sendrecv_replace(values.data(),
-                       n,
-                       get_mpi_type<T>(),
-                       dest,
-                       0,
-                       source,
-                       MPI_ANY_TAG,
-                       comm,
-                       MPI_STATUS_IGNORE);
+  if (rank == dest || rank == source) {
+    MPI_Sendrecv_replace(values.data(),
+                         n,
+                         get_mpi_type<T>(),
+                         dest,
+                         0,
+                         source,
+                         MPI_ANY_TAG,
+                         comm,
+                         MPI_STATUS_IGNORE);
+  }
 }
 
 template<typename T, size_t N>
@@ -248,15 +259,17 @@ void Comm::sendrecv_replace(xt::xtensor<T, N>& values, int dest, int source) con
   auto n = values.size();
   sendrecv_replace(n, dest, source);
   // Finally, broadcast data
-  MPI_Sendrecv_replace(values.data(),
-                       n,
-                       get_mpi_type<T>(),
-                       dest,
-                       0,
-                       source,
-                       MPI_ANY_TAG,
-                       comm,
-                       MPI_STATUS_IGNORE);
+  if (rank == dest || rank == source) {
+    MPI_Sendrecv_replace(values.data(),
+                         n,
+                         get_mpi_type<T>(),
+                         dest,
+                         0,
+                         source,
+                         MPI_ANY_TAG,
+                         comm,
+                         MPI_STATUS_IGNORE);
+  }
 }
 
 template<typename T>

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -189,7 +189,7 @@ public:
 
   //! Displays a message from rank 0
   //! \param A message to display
-  void message(const std::string& msg)
+  void message(const std::string& msg) const
   {
     if (rank == 0)
       std::cout << "[ENRICO]: " << msg << std::endl;

--- a/include/enrico/comm_split.h
+++ b/include/enrico/comm_split.h
@@ -1,7 +1,7 @@
 #ifndef ENRICO_COMM_SPLIT_H
 #define ENRICO_COMM_SPLIT_H
 
-#include "comm.h"
+#include "enrico/comm.h"
 
 #include <array>
 #include <mpi.h>

--- a/include/enrico/comm_split.h
+++ b/include/enrico/comm_split.h
@@ -3,6 +3,7 @@
 
 #include "comm.h"
 
+#include <array>
 #include <mpi.h>
 
 namespace enrico {
@@ -41,6 +42,13 @@ void get_node_comms(Comm super_comm,
                     int procs_per_node,
                     Comm& sub_comm,
                     Comm& intranode_comm);
+
+void get_driver_comms(Comm super_comm,
+                      std::array<int, 2> num_nodes,
+                      std::array<int, 2> procs_per_node,
+                      std::array<Comm, 2>& driver_comms,
+                      Comm& intranode_comm,
+                      Comm& coupling_comm);
 
 }
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -89,6 +89,9 @@ public:
     return get_timestep_index() == 0 and get_picard_index() == 0;
   }
 
+  //! Print report of communicator layout
+  void comm_report();
+
   Comm comm_; //!< The MPI communicator used to run the driver
 
   double power_; //!< Power in [W]

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -222,6 +222,9 @@ private:
 
   //! Number of cell instances in neutronics model
   int32_t n_cells_;
+
+  //! Number of global elements in heat/fluids model
+  int32_t n_global_elem_;
 };
 
 } // namespace enrico

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -157,9 +157,17 @@ private:
 
   int i_picard_; //!< Index pertaining to current Picard iteration
 
-  Comm intranode_comm_;           //!< The communicator representing intranode ranks
+  Comm intranode_comm_; //!< The communicator representing intranode ranks
+  Comm coupling_comm_;  //!< The communicator spanning all nodes
+
   int neutronics_procs_per_node_; //!< Number of MPI ranks per (shared-memory) node in
                                   //!< neutronics comm
+
+  //! The rank in comm_ that corresponds to the root of the neutronics comm
+  int neutronics_root_ = MPI_PROC_NULL;
+
+  //! The rank in comm_ that corresponds to the root of the heat comm
+  int heat_root_ = MPI_PROC_NULL;
 
   //! Current Picard iteration temperature; this temperature is the temperature
   //! computed by the thermal-hydraulic solver, and data mappings may result in

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -33,11 +33,6 @@ public:
   //! Execute the coupled driver
   virtual void execute();
 
-  //! Whether the calling rank has access to the coupled solution
-  //! fields for the heat source, temperature, density, and other protected member
-  //! variables of this class.
-  bool has_global_coupling_data() const;
-
   //! Update the heat source for the thermal-hydraulics solver
   void update_heat_source();
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -110,7 +110,6 @@ std::vector<T> HeatFluidsDriver::gather(const std::vector<T>& local_field) const
     }
 
     // Gather all the local quantities on to the root process
-    comm_.message("Begin vector Gatherv");
     comm_.Gatherv(local_field.data(),
                   local_field.size(),
                   get_mpi_type<T>(),

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -110,6 +110,7 @@ std::vector<T> HeatFluidsDriver::gather(const std::vector<T>& local_field) const
     }
 
     // Gather all the local quantities on to the root process
+    comm_.message("Begin vector Gatherv");
     comm_.Gatherv(local_field.data(),
                   local_field.size(),
                   get_mpi_type<T>(),

--- a/src/comm_split.cpp
+++ b/src/comm_split.cpp
@@ -1,5 +1,4 @@
 #include "enrico/comm_split.h"
-#include <initializer_list>
 
 namespace enrico {
 

--- a/src/comm_split.cpp
+++ b/src/comm_split.cpp
@@ -53,16 +53,7 @@ void get_driver_comms(Comm super_comm,
   intranode_comm.broadcast(total_nodes);
 
   // Each rank gets its node index (inferred from the ranks of the coupling comms)
-  int node_idx;
-  if (coupling_comm.active()) {
-    std::vector<int> v;
-    if (coupling_comm.is_root()) {
-      for (int i = 0; i < total_nodes; ++i) {
-        v.push_back(i);
-      }
-    }
-    MPI_Scatter(v.data(), 1, MPI_INT, &node_idx, 1, MPI_INT, 0, coupling_comm.comm);
-  }
+  int node_idx = coupling_comm.rank;
   intranode_comm.broadcast(node_idx);
 
   // Get the driver comms. driver_comms[0] gets the left-hand nodes, and

--- a/src/comm_split.cpp
+++ b/src/comm_split.cpp
@@ -1,4 +1,5 @@
 #include "enrico/comm_split.h"
+#include <initializer_list>
 
 namespace enrico {
 
@@ -21,6 +22,74 @@ void get_node_comms(Comm super_comm,
   sub_comm = Comm(scomm);
   if (color != 0) {
     sub_comm.free();
+  }
+}
+
+void get_driver_comms(Comm super_comm,
+                      std::array<int, 2> num_nodes,
+                      std::array<int, 2> procs_per_node,
+                      std::array<Comm, 2>& driver_comms,
+                      Comm& intranode_comm,
+                      Comm& coupling_comm)
+{
+  const int KEEP = 0;
+  const int DISCARD = 1;
+  MPI_Comm temp_comm;
+
+  // Each intranode_comm contains all ranks in a given shared memory region (usually node)
+  MPI_Comm_split_type(
+    super_comm.comm, MPI_COMM_TYPE_SHARED, super_comm.rank, MPI_INFO_NULL, &temp_comm);
+  intranode_comm = Comm(temp_comm);
+
+  // The coupling comm consists of the root process on each intranode_comm.
+  int color = intranode_comm.is_root() ? KEEP : DISCARD;
+  MPI_Comm_split(super_comm.comm, color, super_comm.rank, &temp_comm);
+  coupling_comm = Comm(temp_comm);
+  if (color == DISCARD) {
+    coupling_comm.free();
+  }
+
+  // Get the number of nodes (inferred as the size of the coupling comm)
+  int total_nodes = coupling_comm.size;
+  intranode_comm.broadcast(total_nodes);
+
+  // Each rank gets its node index (inferred from the ranks of the coupling comms)
+  int node_idx;
+  if (coupling_comm.active()) {
+    std::vector<int> v;
+    if (coupling_comm.is_root()) {
+      for (int i = 0; i < total_nodes; ++i) {
+        v.push_back(i);
+      }
+    }
+    MPI_Scatter(v.data(), 1, MPI_INT, &node_idx, 1, MPI_INT, 0, coupling_comm.comm);
+  }
+  intranode_comm.broadcast(node_idx);
+
+  // Get the driver comms. driver_comms[0] gets the left-hand nodes, and
+  // driver_comms[1] gets the right-hand nodes, both based on the node_idx
+  for (const int i : {0, 1}) {
+
+    // 0 is the null value for num_nodes and procs_per_node.  In that case, we use the
+    // maximum number of nodes or procs-per-node
+    auto n = num_nodes[i] > 0 ? num_nodes[i] : total_nodes;
+    auto ppn = procs_per_node[i] > 0 ? procs_per_node[i] : intranode_comm.size;
+    auto& scomm = driver_comms[i];
+
+    int color;
+    // Left-hand nodes
+    if (i == 0) {
+      color = (node_idx < n && intranode_comm.rank < ppn) ? KEEP : DISCARD;
+    }
+    // Right-hand nodes
+    else {
+      color = (node_idx >= total_nodes - n && intranode_comm.rank < ppn) ? KEEP : DISCARD;
+    }
+    MPI_Comm_split(super_comm.comm, color, super_comm.rank, &temp_comm);
+    scomm = Comm(temp_comm);
+    if (color == DISCARD) {
+      scomm.free();
+    }
   }
 }
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -15,7 +15,6 @@
 #include <iomanip>
 #include <memory> // for make_unique
 #include <string>
-#include <sys/param.h>
 #include <unistd.h> // for hostname
 
 namespace enrico {
@@ -609,7 +608,7 @@ void CoupledDriver::comm_report()
   Comm world(MPI_COMM_WORLD);
 
   // Padding for fields
-  int hostw = std::max(8, hostname.size()) + 2;
+  int hostw = std::max(8UL, hostname.size()) + 2;
   int rankw = 7;
 
   for (int i = 0; i < world.size; ++i) {

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -15,7 +15,13 @@
 #include <iomanip>
 #include <memory> // for make_unique
 #include <string>
-#include <unistd.h> // for hostname
+
+// For gethostname
+#ifdef _WIN32
+#include <winsock.h>
+#else
+#include <unistd.h>
+#endif
 
 namespace enrico {
 
@@ -508,12 +514,12 @@ void CoupledDriver::init_heat_source()
 
 void CoupledDriver::set_heat_source()
 {
-  const auto& neutronics = this->get_neutronics_driver();
-  auto& heat = this->get_heat_driver();
 
   // Neutronics root has heat source on each of its ranks. We need to make
   // heat source available on each TH rank.
   this->comm_.sendrecv_replace(heat_source_, heat_root_, neutronics_root_);
+
+  auto& heat = this->get_heat_driver();
   heat.comm_.broadcast(heat_source_);
 
   if (heat.active()) {

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -602,9 +602,8 @@ void CoupledDriver::set_density()
 
 void CoupledDriver::comm_report()
 {
-  char c[_POSIX_HOST_NAME_MAX];
-  gethostname(c, _POSIX_HOST_NAME_MAX);
-  std::string hostname{c};
+  std::string hostname{_POSIX_HOST_NAME_MAX};
+  gethostname(hostname.data(), _POSIX_HOST_NAME_MAX);
 
   Comm world(MPI_COMM_WORLD);
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -257,7 +257,7 @@ void CoupledDriver::update_temperature()
 
   // Send heat solver's temperatures to neutronics root
   auto t = heat.temperature();
-  this->comm_.sendrecv_replace(t, neutronics_root_, heat_root_);
+  this->comm_.send_and_recv(t, neutronics_root_, heat_root_);
 
   if (neutronics.comm_.is_root()) {
     // Store previous temperature solution; a previous solution will always be present
@@ -278,7 +278,7 @@ void CoupledDriver::update_density()
 
   // Send heat solver's densities to neutronics root
   auto d = heat.density();
-  this->comm_.sendrecv_replace(d, neutronics_root_, heat_root_);
+  this->comm_.send_and_recv(d, neutronics_root_, heat_root_);
 
   if (neutronics.comm_.is_root()) {
     // Store previous density solution; a previous solution will always be present
@@ -300,7 +300,7 @@ void CoupledDriver::init_mappings()
 
   // Get centroids from heat driver and send to all neutronics procs
   auto elem_centroids = heat.centroids(); // Available only on heat root
-  this->comm_.sendrecv_replace(elem_centroids, neutronics_root_, heat_root_);
+  this->comm_.send_and_recv(elem_centroids, neutronics_root_, heat_root_);
 
   neutronics.comm_.broadcast(elem_centroids);
 
@@ -319,11 +319,11 @@ void CoupledDriver::init_mappings()
   }
 
   // Send element -> cell instance mapping to all heat procs
-  this->comm_.sendrecv_replace(elem_to_cell_, heat_root_, neutronics_root_);
+  this->comm_.send_and_recv(elem_to_cell_, heat_root_, neutronics_root_);
   heat.comm_.broadcast(elem_to_cell_);
 
   // Send number of cell instances to all heat procs
-  this->comm_.sendrecv_replace(n_cells_, heat_root_, neutronics_root_);
+  this->comm_.send_and_recv(n_cells_, heat_root_, neutronics_root_);
   heat.comm_.broadcast(n_cells_);
 }
 
@@ -385,7 +385,7 @@ void CoupledDriver::init_volumes()
 
   // Gather all the local element volumes on heat root and send to all neutronics procs
   elem_volumes_ = heat.volumes();
-  this->comm_.sendrecv_replace(elem_volumes_, neutronics_root_, heat_root_);
+  this->comm_.send_and_recv(elem_volumes_, neutronics_root_, heat_root_);
 
   neutronics.comm_.broadcast(elem_volumes_);
 
@@ -473,7 +473,7 @@ void CoupledDriver::init_elem_fluid_mask()
   elem_fluid_mask_ = heat.fluid_mask();
 
   // Send fluid mask to neutronics procs
-  this->comm_.sendrecv_replace(elem_fluid_mask_, neutronics_root_, heat_root_);
+  this->comm_.send_and_recv(elem_fluid_mask_, neutronics_root_, heat_root_);
   neutronics.comm_.broadcast(elem_fluid_mask_);
 }
 
@@ -518,7 +518,7 @@ void CoupledDriver::set_heat_source()
 
   // Neutronics root has heat source on each of its ranks. We need to make
   // heat source available on each TH rank.
-  this->comm_.sendrecv_replace(heat_source_, heat_root_, neutronics_root_);
+  this->comm_.send_and_recv(heat_source_, heat_root_, neutronics_root_);
 
   auto& heat = this->get_heat_driver();
   heat.comm_.broadcast(heat_source_);

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -608,7 +608,7 @@ void CoupledDriver::comm_report()
   Comm world(MPI_COMM_WORLD);
 
   // Padding for fields
-  int hostw = MAX(8, hostname.size()) + 2;
+  int hostw = std::max(8, hostname.size()) + 2;
   int rankw = 7;
 
   for (int i = 0; i < world.size; ++i) {

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -221,7 +221,7 @@ bool CoupledDriver::is_converged()
     neutron.comm_.message(msg);
   }
 
-  comm_.Bcast(&converged, 1, get_mpi_type<bool>(), neutronics_root_);
+  comm_.broadcast(converged, neutronics_root_);
   return converged;
 }
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -381,29 +381,31 @@ void CoupledDriver::init_volumes()
   // Gather all the local element volumes on heat root and send to all neutronics procs
   elem_volumes_ = heat.volumes();
   this->comm_.sendrecv_replace(elem_volumes_, neutronics_root_, heat_root_);
-  neutronics.comm_.broadcast(elem_volumes_);
 
-  // Volume check
-  if (neutronics.comm_.is_root()) {
-    for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
-      double v_neutronics = neutronics.get_volume(cell);
-      double v_heatfluids = 0.0;
-      for (const auto& elem : cell_to_elems_.at(cell)) {
-        v_heatfluids += elem_volumes_.at(elem);
-      }
+  if (neutronics.active()) {
+    neutronics.comm_.broadcast(elem_volumes_);
 
-      // TODO: Refactor to avoid dynamic_cast
-      const auto* openmc_driver = dynamic_cast<const OpenmcDriver*>(&neutronics);
-      if (openmc_driver) {
-        const auto& c = openmc_driver->cells_[cell];
-        std::stringstream msg;
-        msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
-            << "), V = " << v_neutronics << " (Neutronics), " << v_heatfluids
-            << " (Heat/Fluids)";
-        comm_.message(msg.str());
+    // Volume check
+    if (neutronics.comm_.is_root()) {
+      for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
+        double v_neutronics = neutronics.get_volume(cell);
+        double v_heatfluids = 0.0;
+        for (const auto& elem : cell_to_elems_.at(cell)) {
+          v_heatfluids += elem_volumes_.at(elem);
+        }
+
+        // TODO: Refactor to avoid dynamic_cast
+        const auto* openmc_driver = dynamic_cast<const OpenmcDriver*>(&neutronics);
+        if (openmc_driver) {
+          const auto& c = openmc_driver->cells_[cell];
+          std::stringstream msg;
+          msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
+              << "), V = " << v_neutronics << " (Neutronics), " << v_heatfluids
+              << " (Heat/Fluids)";
+          comm_.message(msg.str());
+        }
       }
     }
-    MPI_Abort(comm_.comm, MPI_ERR_BASE);
   }
 }
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -602,8 +602,9 @@ void CoupledDriver::set_density()
 
 void CoupledDriver::comm_report()
 {
-  std::string hostname{_POSIX_HOST_NAME_MAX};
-  gethostname(hostname.data(), _POSIX_HOST_NAME_MAX);
+  char c[_POSIX_HOST_NAME_MAX];
+  gethostname(c, _POSIX_HOST_NAME_MAX);
+  std::string hostname{c};
 
   Comm world(MPI_COMM_WORLD);
 

--- a/tests/disjoint_bcast_debug/main.cpp
+++ b/tests/disjoint_bcast_debug/main.cpp
@@ -4,15 +4,18 @@
 #include "pugixml.hpp"
 
 #include <array>
+#include <iostream>
+#include <iomanip>
+#include <unistd.h>
 
 class TestDriver {
 public:
-  enrico::Comm left_comm, right_comm;
+  enrico::Comm left, right;
 
   TestDriver()
   {
     std::array<int, 2> nodes{2, 2};
-    std::array<int, 2> procs_per_node{4, 1};
+    std::array<int, 2> procs_per_node{1, 4};
 
     enrico::Comm super_comm(MPI_COMM_WORLD);
     std::array<enrico::Comm, 2> driver_comms;
@@ -21,18 +24,49 @@ public:
     enrico::get_driver_comms(
       super_comm, nodes, procs_per_node, driver_comms, intranode_comm, coupling_comm);
 
-    left_comm = driver_comms[0];
-    right_comm = driver_comms[1];
+    left = driver_comms[0];
+    right = driver_comms[1];
   }
 
-  void test_right_bcast()
+  void test_bcast(enrico::Comm c)
   {
-    if (right_comm.comm != MPI_COMM_NULL) {
-      double val = right_comm.rank == 0 ? 3.14 : 0.0;
-      MPI_Bcast(&val, 1, MPI_DOUBLE, 0, right_comm.comm);
+    if (c.comm != MPI_COMM_NULL) {
+      double val = c.rank == 0 ? 3.14 : 0.0;
+      MPI_Bcast(&val, 1, MPI_DOUBLE, 0, c.comm);
 
-      right_comm.message("Rank " + std::to_string(right_comm.rank) +
-                         ": val = " + std::to_string(val));
+      for (int i = 0; i < c.size; ++i) {
+        c.message("Rank " + std::to_string(c.rank) + ": val = " + std::to_string(val),
+                           i);
+      }
+    }
+  }
+
+  void comm_report()
+  {
+    char c[_POSIX_HOST_NAME_MAX];
+    gethostname(c, _POSIX_HOST_NAME_MAX);
+    std::string hostname{c};
+
+    enrico::Comm world(MPI_COMM_WORLD);
+
+    // Padding for fields
+    int hostw = std::max(8UL, hostname.size()) + 2;
+    int rankw = 7;
+
+    for (int i = 0; i < world.size; ++i) {
+      if (world.rank == i) {
+        if (i == 0) {
+          std::cout << std::left << std::setw(hostw) << "Hostname" << std::right
+                    << std::setw(rankw) << "World" << std::right 
+                    << std::setw(rankw) << "Left" << std::right 
+                    << std::setw(rankw) << "Right" << std::endl;
+        }
+        std::cout << std::left << std::setw(hostw) << hostname << std::right
+                  << std::setw(rankw) << world.rank << std::right 
+                  << std::setw(rankw) << left.rank << std::right 
+                  << std::setw(rankw) << right.rank << std::endl;
+      }
+      MPI_Barrier(world.comm);
     }
   }
 };
@@ -42,7 +76,8 @@ int main(int argc, char* argv[])
   MPI_Init(&argc, &argv);
 
   TestDriver d;
-  d.test_right_bcast();
+  d.comm_report();
+  d.test_bcast(d.left);
 
   MPI_Finalize();
 }

--- a/tests/disjoint_bcast_debug/main.cpp
+++ b/tests/disjoint_bcast_debug/main.cpp
@@ -1,0 +1,48 @@
+#include "enrico/comm.h"
+#include "enrico/comm_split.h"
+#include "mpi.h"
+#include "pugixml.hpp"
+
+#include <array>
+
+class TestDriver {
+public:
+  enrico::Comm left_comm, right_comm;
+
+  TestDriver()
+  {
+    std::array<int, 2> nodes{2, 2};
+    std::array<int, 2> procs_per_node{4, 1};
+
+    enrico::Comm super_comm(MPI_COMM_WORLD);
+    std::array<enrico::Comm, 2> driver_comms;
+    enrico::Comm intranode_comm, coupling_comm;
+
+    enrico::get_driver_comms(
+      super_comm, nodes, procs_per_node, driver_comms, intranode_comm, coupling_comm);
+
+    left_comm = driver_comms[0];
+    right_comm = driver_comms[1];
+  }
+
+  void test_right_bcast()
+  {
+    if (right_comm.comm != MPI_COMM_NULL) {
+      double val = right_comm.rank == 0 ? 3.14 : 0.0;
+      MPI_Bcast(&val, 1, MPI_DOUBLE, 0, right_comm.comm);
+
+      right_comm.message("Rank " + std::to_string(right_comm.rank) +
+                         ": val = " + std::to_string(val));
+    }
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  MPI_Init(&argc, &argv);
+
+  TestDriver d;
+  d.test_right_bcast();
+
+  MPI_Finalize();
+}

--- a/tests/disjoint_comm_demo/enrico.xml
+++ b/tests/disjoint_comm_demo/enrico.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<enrico>
+  <neutronics_procs_per_node>1</neutronics_procs_per_node>
+  <heat_fluids_procs_per_node>3</heat_fluids_procs_per_node>
+  <!--
+    <neutronics_nodes>-1</neutronics_nodes>
+    <heat_fluids_procs_per_node>-1</heat_fluids_procs_per_node>
+    <heat_fluids_procs_per_node>-1</heat_fluids_procs_per_node>
+  -->
+</enrico>

--- a/tests/disjoint_comm_demo/enrico.xml
+++ b/tests/disjoint_comm_demo/enrico.xml
@@ -2,9 +2,4 @@
 <enrico>
   <neutronics_procs_per_node>1</neutronics_procs_per_node>
   <heat_fluids_procs_per_node>3</heat_fluids_procs_per_node>
-  <!--
-    <neutronics_nodes>-1</neutronics_nodes>
-    <heat_fluids_procs_per_node>-1</heat_fluids_procs_per_node>
-    <heat_fluids_procs_per_node>-1</heat_fluids_procs_per_node>
-  -->
 </enrico>

--- a/tests/disjoint_comm_demo/main.cpp
+++ b/tests/disjoint_comm_demo/main.cpp
@@ -1,0 +1,63 @@
+#include "enrico/comm.h"
+#include "enrico/comm_split.h"
+#include "pugixml.hpp"
+
+#include <mpi.h>
+#include <unistd.h>
+
+class DisjointDriver {
+public:
+  DisjointDriver(MPI_Comm comm, pugi::xml_node node);
+
+  enrico::Comm super_comm;
+
+  std::array<enrico::Comm, 2> driver_comms;
+  enrico::Comm intranode_comm, coupling_comm;
+};
+
+DisjointDriver::DisjointDriver(MPI_Comm comm, pugi::xml_node node)
+  : super_comm(comm)
+{
+  std::array<int, 2> nodes{node.child("neutronics_nodes").text().as_int(),
+                           node.child("heat_fluids_nodes").text().as_int()};
+  std::array<int, 2> procs_per_node{
+    node.child("neutronics_procs_per_node").text().as_int(),
+    node.child("heat_fluids_procs_per_node").text().as_int()};
+  enrico::get_driver_comms(
+    super_comm, nodes, procs_per_node, driver_comms, intranode_comm, coupling_comm);
+}
+
+int main(int argc, char* argv[])
+{
+  MPI_Init(&argc, &argv);
+
+  char hostname[_POSIX_HOST_NAME_MAX];
+  gethostname(hostname, _POSIX_HOST_NAME_MAX);
+
+  // Parse enrico.xml file
+  pugi::xml_document doc;
+  auto result = doc.load_file("enrico.xml");
+  if (!result) {
+    throw std::runtime_error{"Unable to load enrico.xml file"};
+  }
+  // Get root element
+  auto root = doc.document_element();
+
+  enrico::Comm world(MPI_COMM_WORLD);
+
+  DisjointDriver driver(world.comm, root);
+  for (int i = 0; i < world.size; ++i) {
+    if (world.rank == i) {
+      if (i == 0) {
+        std::cout << "Host\t\tWorld\tLeft\tRight\tIntra\tCoup" << std::endl;
+      }
+      std::cout << hostname << "\t" << world.rank << "\t" << driver.driver_comms[0].rank
+                << "\t" << driver.driver_comms[1].rank << "\t"
+                << driver.intranode_comm.rank << "\t" << driver.coupling_comm.rank << "\t"
+                << std::endl;
+    }
+    MPI_Barrier(world.comm);
+  }
+
+  MPI_Finalize();
+}


### PR DESCRIPTION
This PR allows the heat and neutronics drivers to run on arbitrarily disjoint or overlapping communicators.  The communication scheme is the same, no matter if the communicators are fully overlapping, partially overlapping, or fully disjoint.  

## Notable Changes

### `get_driver_comms`

The communicators are created in `get_driver_comms`: 
* Given two numbers each for number-of-nodes and procs-per-node, It creates two new communicators.  Once consists of "left-hand" nodes (based on an arbitrary node index, determined at runtime) and the other consists of right-hand nodes.  
* It also returns the internode comms, but these are not currently used in `CoupledDriver`.

### `Comm`

`Comm` has a new set of templated member functions, `sendrecv_replace`, which are used in `CoupledDriver` to transfer data between the heat comm's root and the neutron comm's root.  To do so, `CoupledDriver` determine's the ranks *in its own communicator* of the heat and neutron comm's roots; and then does the sendrecv in its own communicator between those ranks.  

### `CoupledDriver`

`CoupledDriver` has the most lines of code changed, but the logic isn't so different. Before, we commonly did gathervs or broadcasts to/from one single-physics driver's root; and since the comms were overlapping, that implied that the data was also on the other single-physics driver's root.  Here, we need an extra sendrecv to ensure that the data is on the other single-physics driver's root.  

Below is an example of doing a temperature transfer using the new communication scheme.  For each step, we see two cases: one where the communicators overlap, and one where they're completely disjoint.  Note that in both cases, we do the same MPI operation.  

* Step 1:  Gatherv temperature to Nek root across Nek comm:  https://www.dropbox.com/s/vpfbarbi4om6ge9/disjoint_comms_01.png
* Step 2: Sendrecv temperature from Nek root to OpenMC root:  https://www.dropbox.com/s/t6vjm5cmlsst6n1/disjoint_comms_02.png
* Step 3: Bcast temperature from OpenMC root across OpenMC Comm https://www.dropbox.com/s/yl05kirg382rjy0/disjoint_comms_03.png