### PR TITLE
Improve iteration over cell-element mappings 

### DIFF
--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -211,7 +211,7 @@ private:
   //! operation, and do not reflect TH internal global element indexing.
   std::vector<CellHandle> elem_to_cell_;
 
-  //! Number of cell instances in neutronics model
+  //! Number of unique cells in neutronics model
   int32_t n_cells_;
 
   //! Number of global elements in heat/fluids model

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -71,6 +71,11 @@ public:
 
   //! Create energy production tallies
   virtual void create_tallies() = 0;
+
+  //! Get a label for a cell
+  //! \param cell Handle to a clel
+  //! \return Label for the cell
+  virtual std::string cell_label(CellHandle cell) const = 0;
 };
 
 } // namespace enrico

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -27,6 +27,9 @@ public:
   //! One-time finalization of OpenMC
   ~OpenmcDriver();
 
+  //////////////////////////////////////////////////////////////////////////////
+  // NeutronicsDriver interface
+
   //! Find cells corresponding to a vector of positions
   //! \param positions (x,y,z) coordinates to search for
   //! \return Handles to cells
@@ -70,6 +73,9 @@ public:
   //! Determine number of cells participating in coupling
   //! \return Number of cells
   xt::xtensor<double, 1> heat_source(double power) const final;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Driver interface
 
   //! Initialization required in each Picard iteration
   void init_step() final;

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -74,6 +74,8 @@ public:
   //! \return Number of cells
   xt::xtensor<double, 1> heat_source(double power) const final;
 
+  std::string cell_label(CellHandle cell) const;
+
   //////////////////////////////////////////////////////////////////////////////
   // Driver interface
 
@@ -91,7 +93,8 @@ public:
   //! Finalization required in each Picard iteration
   void finalize_step() final;
 
-  // Data
+private:
+  // Data members
   openmc::Tally* tally_;               //!< Fission energy deposition tally
   openmc::CellInstanceFilter* filter_; //!< Cell instance filter
   std::vector<CellInstance> cells_;    //!< Array of cell instances

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -317,19 +317,21 @@ void CoupledDriver::update_temperature(bool relax)
 
   if (neutronics.active()) {
     // For each neutronics cell, volume average temperatures and set
-    for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
+    for (const auto& kv : cell_to_elems_) {
       // Get volume-average temperature for this cell instance
       double average_temp = 0.0;
       double total_vol = 0.0;
-      for (int elem : cell_to_elems_.at(cell)) {
+      for (int elem : kv.second) {
         double T = temperatures_[elem];
         double V = elem_volumes_[elem];
         average_temp += T * V;
         total_vol += V;
       }
-      // Set temperature for cell instance
       average_temp /= total_vol;
       Ensures(average_temp > 0.0);
+
+      // Set temperature for cell instance
+      CellHandle cell = kv.first;
       neutronics.set_temperature(cell, average_temp);
     }
   }
@@ -365,12 +367,13 @@ void CoupledDriver::update_density(bool relax)
   if (neutronics.active()) {
     // For each neutronics cell in a fluid cell, volume average the densities
     // and set in driver
-    for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
+    for (const auto& kv : cell_to_elems_) {
+      CellHandle cell = kv.first;
       if (cell_fluid_mask_[cell] == 1) {
         // Get volume-averaged density for this cell instance
         double average_density = 0.0;
         double total_vol = 0.0;
-        for (int e : cell_to_elems_.at(cell)) {
+        for (int e : kv.second) {
           average_density += densities_[e] * elem_volumes_[e];
           total_vol += elem_volumes_[e];
         }
@@ -483,10 +486,11 @@ void CoupledDriver::init_volumes()
 
   // Volume check
   if (neutronics.comm_.is_root()) {
-    for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
+    for (const auto& kv : cell_to_elems_) {
+      CellHandle cell = kv.first;
       double v_neutronics = neutronics.get_volume(cell);
       double v_heatfluids = 0.0;
-      for (const auto& elem : cell_to_elems_.at(cell)) {
+      for (const auto& elem : kv.second) {
         v_heatfluids += elem_volumes_.at(elem);
       }
 
@@ -525,8 +529,11 @@ void CoupledDriver::init_densities()
       // index in the densities_ array. This mapping assumes that each TH
       // element is fully contained within a neutronics cell, i.e., TH elements
       // are not split between multiple neutronics cells.
-      for (CellHandle cell = 0; cell < cell_to_elems_.size(); ++cell) {
-        for (int elem : cell_to_elems_.at(cell)) {
+      for (const auto& kv : cell_to_elems_) {
+        CellHandle cell = kv.first;
+        const auto& global_elems = kv.second;
+
+        for (int elem : global_elems) {
           if (cell_fluid_mask_[cell] == 1) {
             double rho = neutronics.get_density(cell);
             densities_[elem] = rho;
@@ -574,9 +581,9 @@ void CoupledDriver::init_cell_fluid_mask()
     auto n = cell_to_elems_.size();
     cell_fluid_mask_.resize({n});
 
-    for (CellHandle cell = 0; cell < n; ++cell) {
-      auto elems = cell_to_elems_.at(cell);
-      for (const auto& elem : elems) {
+    for (const auto& kv : cell_to_elems_) {
+      CellHandle cell = kv.first;
+      for (const auto& elem : kv.second) {
         if (elem_fluid_mask_[elem] == 1) {
           cell_fluid_mask_[cell] = 1;
           break;

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -494,16 +494,11 @@ void CoupledDriver::init_volumes()
         v_heatfluids += elem_volumes_.at(elem);
       }
 
-      // TODO: Refactor to avoid dynamic_cast
-      const auto* openmc_driver = dynamic_cast<const OpenmcDriver*>(&neutronics);
-      if (openmc_driver) {
-        const auto& c = openmc_driver->cells_[cell];
-        std::stringstream msg;
-        msg << "Cell " << openmc::model::cells[c.index_]->id_ << " (" << c.instance_
-            << "), V = " << v_neutronics << " (Neutronics), " << v_heatfluids
-            << " (Heat/Fluids)";
-        comm_.message(msg.str());
-      }
+      // Display volumes
+      std::stringstream msg;
+      msg << "Cell " << neutronics.cell_label(cell) << ", V = " << v_neutronics
+          << " (Neutronics), " << v_heatfluids << " (Heat/Fluids)";
+      comm_.message(msg.str());
     }
   }
 }

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -99,7 +99,7 @@ xt::xtensor<double, 1> OpenmcDriver::heat_source(double power) const
 
     // Convert heat from [J/source] to [W/cm^3]. Dividing by total_heat gives
     // the fraction of heat deposited in each material. Multiplying by power
-    // givens an absolute value in W
+    // gives an absolute value in W.
     heat(i) *= power / (total_heat * V);
   }
 

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -163,6 +163,17 @@ bool OpenmcDriver::is_fissionable(CellHandle cell) const
   return cells_[cell].material()->fissionable();
 }
 
+std::string OpenmcDriver::cell_label(CellHandle cell) const
+{
+  // Get cell instance
+  const auto& c = cells_[cell];
+
+  // Build label
+  std::stringstream label;
+  label << openmc::model::cells[c.index_]->id_ << " (" << c.instance_ << ")";
+  return label.str();
+}
+
 void OpenmcDriver::init_step()
 {
   err_chk(openmc_simulation_init());


### PR DESCRIPTION
There's a built-in assumption in much of our code that the "cell handles" that the neutronics driver returns start sequentially from zero. This pull request makes some progress in avoiding this assumption by changing how we iterate over the `cell_to_elems_` member in `CoupledDriver`. Rather than iterating from `0 ... cell_to_elems_.size() - 1`, we now just rely on range-based iterators provided by `unordered_map`.

A few other small tweaks in this PR:

- Introduce a `cell_label` abstract method for neutronics drivers. This avoids one remaining piece of the `CoupledDriver` logic where we access OpenMC internals, instead deferring to this new abstract method for the driver to provide what is needed.
- Along the same lines, all data members of `OpenmcDriver` are now private.