### PR TITLE
Updates to ENRICO build process to allow for optional nek build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.3)
 project(enrico Fortran C CXX)
 
+option(NEK_BUILD  "Determines if Nek5000 will be included" ON)
+
+if (NEK_BUILD)
+    add_definitions(-DNEK_BUILD)
+endif()
+
 # On BG/Q, linking requires -dynamic, not -rdynamic
 if (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ppc64")
   set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "-dynamic")
@@ -20,15 +26,17 @@ endif ()
 # =============================================================================
 # Discover name-mangling for routines in libnek5000
 # =============================================================================
-include(FortranCInterface)
-FortranCInterface_VERIFY()
-FortranCInterface_HEADER(${CMAKE_BINARY_DIR}/nek_mangling.h
-    MACRO_NAMESPACE C2F_
-    SYMBOL_NAMESPACE C2F_
-    SYMBOLS
-    nek_init
-    nek_end
-    nek_solve)
+if (NEK_BUILD)
+    include(FortranCInterface)
+    FortranCInterface_VERIFY()
+    FortranCInterface_HEADER(${CMAKE_BINARY_DIR}/nek_mangling.h
+        MACRO_NAMESPACE C2F_
+        SYMBOL_NAMESPACE C2F_
+        SYMBOLS
+        nek_init
+        nek_end
+        nek_solve)
+endif()
 
 # =============================================================================
 # Headers for all targets
@@ -49,7 +57,9 @@ endif ()
 # =============================================================================
 # Recursively build libnek5000 and libopenmc
 # =============================================================================
-add_subdirectory(vendor/nek5000)
+if (NEK_BUILD)
+    add_subdirectory(vendor/nek5000)
+endif()
 add_subdirectory(vendor/openmc)
 
 # =============================================================================
@@ -78,9 +88,13 @@ set(SOURCES
     src/mpi_types.cpp
     src/openmc_driver.cpp
     src/cell_instance.cpp
-    src/nek_driver.cpp
     src/vtk_viz.cpp
     src/heat_fluids_driver.cpp)
+
+if (NEK_BUILD)
+    list(APPEND SOURCES
+        src/nek_driver.cpp)
+endif()
 
 if (SCALE_FOUND)
     list(APPEND SOURCES
@@ -101,8 +115,12 @@ add_library(libenrico
             ${SOURCES})
 
 set_target_properties(libenrico PROPERTIES OUTPUT_NAME enrico)
-target_link_libraries(libenrico PUBLIC iapws libnek5000 libopenmc xtensor heat_xfer pugixml gsl-lite)
+target_link_libraries(libenrico PUBLIC iapws libopenmc xtensor heat_xfer pugixml gsl-lite)
 target_compile_definitions(libenrico PRIVATE GSL_THROW_ON_CONTRACT_VIOLATION)
+
+if (NEK_BUILD)
+    target_link_libraries(libenrico PUBLIC libnek5000)
+endif()
 
 if (SCALE_FOUND)
   target_link_libraries(libenrico PUBLIC ${SCALE_LIBRARIES})
@@ -120,9 +138,6 @@ target_link_libraries(enrico PUBLIC libenrico)
 # =============================================================================
 add_executable(comm_split_demo tests/comm_split_demo/main.cpp)
 
-add_executable(test_nek5000_singlerod tests/singlerod/short/test_nek5000.cpp)
-target_link_libraries(test_nek5000_singlerod PUBLIC libenrico)
-
 add_executable(test_openmc_singlerod tests/singlerod/short/test_openmc.cpp)
 target_link_libraries(test_openmc_singlerod PUBLIC libenrico)
 
@@ -132,9 +147,18 @@ set_target_properties(
         comm_split_demo
         heat_xfer
         iapws
-        test_nek5000_singlerod
         test_openmc_singlerod
         PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+
+
+if (NEK_BUILD)
+    add_executable(test_nek5000_singlerod tests/singlerod/short/test_nek5000.cpp)
+    target_link_libraries(test_nek5000_singlerod PUBLIC libenrico)
+
+    set_target_properties(
+        test_nek5000_singlerod
+        PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
+endif()
 
 if (SCALE_FOUND)
   add_executable(test_shift_singlerod tests/singlerod/short/test_shift_coupled.cpp)

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -3,7 +3,11 @@
 #include "enrico/comm_split.h"
 #include "enrico/driver.h"
 #include "enrico/error.h"
+
+#ifdef NEK_BUILD
 #include "enrico/nek_driver.h"
+#endif
+
 #include "enrico/openmc_driver.h"
 #include "enrico/surrogate_heat_driver.h"
 
@@ -121,7 +125,11 @@ CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
   // Instantiate heat-fluids driver
   std::string s = heat_node.child_value("driver");
   if (s == "nek5000") {
+#ifdef NEK_BUILD
     heat_fluids_driver_ = std::make_unique<NekDriver>(heat_comm.comm, heat_node);
+#else
+    throw std::runtime_error{"nek5000 driver selected but not ON in build options"};
+#endif
   } else if (s == "surrogate") {
     heat_fluids_driver_ =
       std::make_unique<SurrogateHeatDriver>(heat_comm.comm, heat_node);


### PR DESCRIPTION
This PR addresses #92 by making adjustments to the CMake build files, and adding a check that ENRICO is built with support for Nek5000 at runtime.