### PR TITLE
Removed some unnecessary `explicit` declarations

### DIFF
--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -34,7 +34,7 @@ public:
   //!
   //! \param comm The MPI communicator used for the coupled driver
   //! \param node XML node containing settings
-  explicit CoupledDriver(MPI_Comm comm, pugi::xml_node node);
+  CoupledDriver(MPI_Comm comm, pugi::xml_node node);
 
   ~CoupledDriver() {}
 

--- a/include/enrico/heat_fluids_driver.h
+++ b/include/enrico/heat_fluids_driver.h
@@ -16,7 +16,7 @@ namespace enrico {
 //! Base class for driver that controls a heat-fluids solve
 class HeatFluidsDriver : public Driver {
 public:
-  explicit HeatFluidsDriver(MPI_Comm comm, pugi::xml_node node);
+  HeatFluidsDriver(MPI_Comm comm, pugi::xml_node node);
 
   virtual ~HeatFluidsDriver() = default;
 

--- a/include/enrico/nek_driver.h
+++ b/include/enrico/nek_driver.h
@@ -24,7 +24,7 @@ public:
   //! NekDriver.
   //!
   //! \param comm  The MPI communicator used to initialze Nek5000
-  explicit NekDriver(MPI_Comm comm, pugi::xml_node xml_root);
+  NekDriver(MPI_Comm comm, pugi::xml_node xml_root);
 
   //! Finalizes Nek5000.
   //!

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -157,7 +157,7 @@ public:
   //!
   //! \param comm  The MPI communicator used to initialze the surrogate
   //! \param node  XML node containing settings for surrogate
-  explicit SurrogateHeatDriver(MPI_Comm comm, pugi::xml_node node);
+  SurrogateHeatDriver(MPI_Comm comm, pugi::xml_node node);
 
   //! Verbosity options for printing simulation results
   enum class verbose { NONE, LOW, HIGH };


### PR DESCRIPTION
In a few places, we declared constructors with > 1 parameter as `explicit`.  This PR omits the unnecessary declarations