### PR TITLE
Cleaned-up C -> Fortran indexing in NekDriver and CoupledDriver

### DIFF
--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -309,8 +309,8 @@ void CoupledDriver::update_heat_source(bool relax)
     auto displacement = heat.local_displs_.at(heat.comm_.rank);
     int n_local_elem = heat.n_local_elem();
     // Set heat source in every element
-    for (int32_t local_elem = 1; local_elem <= n_local_elem; ++local_elem) {
-      int32_t global_elem = local_elem + displacement - 1;
+    for (int32_t local_elem = 0; local_elem < n_local_elem; ++local_elem) {
+      int32_t global_elem = local_elem + displacement;
       // Get heat source for this element
       CellHandle cell = elem_to_cell_.at(global_elem);
       err_chk(heat.set_heat_source_at(local_elem, heat_source_.at(cell)),

--- a/src/nek_driver.cpp
+++ b/src/nek_driver.cpp
@@ -50,7 +50,7 @@ std::vector<double> NekDriver::temperature_local() const
   // Each Nek proc finds the temperatures of its local elements
   std::vector<double> local_elem_temperatures(nelt_);
   for (int32_t i = 0; i < nelt_; ++i) {
-    local_elem_temperatures[i] = this->temperature_at(i + 1);
+    local_elem_temperatures[i] = this->temperature_at(i);
   }
 
   return local_elem_temperatures;
@@ -60,7 +60,7 @@ std::vector<int> NekDriver::fluid_mask_local() const
 {
   std::vector<int> local_fluid_mask(nelt_);
   for (int32_t i = 0; i < nelt_; ++i) {
-    local_fluid_mask[i] = this->in_fluid_at(i + 1);
+    local_fluid_mask[i] = this->in_fluid_at(i);
   }
   return local_fluid_mask;
 }
@@ -70,8 +70,8 @@ std::vector<double> NekDriver::density_local() const
   std::vector<double> local_densities(nelt_);
 
   for (int32_t i = 0; i < nelt_; ++i) {
-    if (this->in_fluid_at(i + 1) == 1) {
-      auto T = this->temperature_at(i + 1);
+    if (this->in_fluid_at(i) == 1) {
+      auto T = this->temperature_at(i);
       // nu1 returns specific volume in [m^3/kg]
       local_densities[i] = 1.0e-3 / iapws::nu1(pressure_bc_, T);
     } else {
@@ -91,7 +91,7 @@ void NekDriver::solve_step()
 Position NekDriver::centroid_at(int32_t local_elem) const
 {
   double x, y, z;
-  err_chk(nek_get_local_elem_centroid(local_elem, &x, &y, &z),
+  err_chk(nek_get_local_elem_centroid(local_elem + 1, &x, &y, &z),
           "Could not find centroid of local element " + std::to_string(local_elem));
   return {x, y, z};
 }
@@ -101,7 +101,7 @@ std::vector<Position> NekDriver::centroid_local() const
   int n_local = this->n_local_elem();
   std::vector<Position> local_element_centroids(n_local);
   for (int32_t i = 0; i < n_local; ++i) {
-    local_element_centroids[i] = this->centroid_at(i + 1);
+    local_element_centroids[i] = this->centroid_at(i);
   }
   return local_element_centroids;
 }
@@ -109,7 +109,7 @@ std::vector<Position> NekDriver::centroid_local() const
 double NekDriver::volume_at(int32_t local_elem) const
 {
   double volume;
-  err_chk(nek_get_local_elem_volume(local_elem, &volume),
+  err_chk(nek_get_local_elem_volume(local_elem + 1, &volume),
           "Could not find volume of local element " + std::to_string(local_elem));
   return volume;
 }
@@ -119,7 +119,7 @@ std::vector<double> NekDriver::volume_local() const
   int n_local = this->n_local_elem();
   std::vector<double> local_elem_volumes(n_local);
   for (int32_t i = 0; i < n_local; ++i) {
-    local_elem_volumes[i] = this->volume_at(i + 1);
+    local_elem_volumes[i] = this->volume_at(i);
   }
   return local_elem_volumes;
 }
@@ -127,20 +127,20 @@ std::vector<double> NekDriver::volume_local() const
 double NekDriver::temperature_at(int32_t local_elem) const
 {
   double temperature;
-  err_chk(nek_get_local_elem_temperature(local_elem, &temperature),
+  err_chk(nek_get_local_elem_temperature(local_elem + 1, &temperature),
           "Could not find temperature of local element " + std::to_string(local_elem));
   return temperature;
 }
 
 int NekDriver::in_fluid_at(int32_t local_elem) const
 {
-  return nek_local_elem_is_in_fluid(local_elem);
+  return nek_local_elem_is_in_fluid(local_elem + 1);
 }
 
 int NekDriver::set_heat_source_at(int32_t local_elem, double heat)
 {
-  Expects(local_elem >= 1 && local_elem <= nelt_);
-  return nek_set_heat_source(local_elem, heat);
+  Expects(local_elem >= 0 && local_elem < nelt_);
+  return nek_set_heat_source(local_elem + 1, heat);
 }
 
 NekDriver::~NekDriver()

--- a/src/surrogate_heat_driver.cpp
+++ b/src/surrogate_heat_driver.cpp
@@ -377,14 +377,14 @@ std::vector<double> SurrogateHeatDriver::volume_local() const
 
 int SurrogateHeatDriver::set_heat_source_at(int32_t local_elem, double heat)
 {
-  if (local_elem > n_pins_ * n_axial_ * n_rings() * n_azimuthal_)
+  if (local_elem >= n_pins_ * n_axial_ * n_rings() * n_azimuthal_)
     return 0;
 
   // Determine indices
-  gsl::index pin = (local_elem - 1) / (n_axial_ * n_rings() * n_azimuthal_);
-  gsl::index axial = ((local_elem - 1) / (n_rings() * n_azimuthal_)) % n_axial_;
-  gsl::index ring = ((local_elem - 1) / n_azimuthal_) % n_rings();
-  gsl::index azimuthal = (local_elem - 1) % n_azimuthal_;
+  gsl::index pin = local_elem / (n_axial_ * n_rings() * n_azimuthal_);
+  gsl::index axial = (local_elem / (n_rings() * n_azimuthal_)) % n_axial_;
+  gsl::index ring = (local_elem / n_azimuthal_) % n_rings();
+  gsl::index azimuthal = local_elem % n_azimuthal_;
 
   // Set heat source
   source_(pin, axial, ring, azimuthal) = heat;


### PR DESCRIPTION
This cleans up `NekDriver` by pushing the one-off adjustment further down into the API.  `NekDriver::temperature_at`, `NekDriver::set_heat_source_at`, etc., are now called with 0-based indices.  Then when the Nek interface functions (defined in Fortran) are called, the indices are increased by 1 in the argument lists.  

Importantly, it also updates a for loop in `CoupledDriver::update_heat_source` that used 1-based indexing.  The change was propagated to `SurrogateHeatDriver::set_heat_source_at`.  

Fixes #101 