### PR TITLE
Temperature_ic, density_ic vals from XML

### DIFF
--- a/doc/source/input.rst
+++ b/doc/source/input.rst
@@ -191,7 +191,7 @@ value of "robbins-monro" indicates that Robbins-Monro relaxation is to be used:
 The initial temperature distribution can be determined either from the
 neutronics solver or the heat-fluids solver. A value of "neutronics" will use
 the temperatures specified in the model for the neutronics solver whereas a
-value of "heat" will use the temperatures specified in the model for the
+value of "heat_fluids" will use the temperatures specified in the model for the
 heat-fluids solver.
 
 *Default*: neutronics
@@ -202,7 +202,7 @@ heat-fluids solver.
 The initial density distribution can be determined either from the
 neutronics solver or the heat-fluids solver. A value of "neutronics" will use
 the densities specified in the model for the neutronics solver whereas a
-value of "heat" will use the densities specified in the model for the
+value of "heat_fluids" will use the densities specified in the model for the
 heat-fluids solver. Note that this density initial condition strictly refers
 to the fluid density - the solid density is constant throughout the simulation,
 and is unchanged from the value used in the neutronics input.

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -79,7 +79,7 @@ CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
   }
 
   if (coup_node.child("temperature_ic")) {
-    auto s = coup_node.child_value("temperature_ic");
+    std::string s = coup_node.child_value("temperature_ic");
 
     if (s == "neutronics") {
       temperature_ic_ = Initial::neutronics;
@@ -91,7 +91,7 @@ CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)
   }
 
   if (coup_node.child("density_ic")) {
-    auto s = coup_node.child_value("density_ic");
+    std::string s = coup_node.child_value("density_ic");
 
     if (s == "neutronics") {
       density_ic_ = Initial::neutronics;


### PR DESCRIPTION
In the docs for `enrico.xml`, the allowed values for `<temperature_ic>` and `<density_ic>` were listed incorrectly.  The allowed value for the heat/fluid driver should be "heat_fluids" instead of "heat".