### PR TITLE
Update NekRS submodule; run nrspre in CI

### DIFF
--- a/ci/test_singlerod_openmc_nekrs.sh
+++ b/ci/test_singlerod_openmc_nekrs.sh
@@ -3,4 +3,5 @@ set -ex
 
 cd tests/singlerod/short/openmc_nekrs
 export NEKRS_HOME=$(realpath ../build/install)
+../build/install/bin/nrspre rod_short 2
 mpirun -np 2 ../build/install/bin/enrico


### PR DESCRIPTION
This updates the NekRS submodule to pull specific commit hashes of OCCA and Nek5000.  Upstream NekRS pulls OCCA and Nek5000 from their respective master branches at configure time; however, this introduced some version skew that broke the builds.  By pulling from specific commit hashes (rather than branches) we should be able to avoid this version skew.  