### PR TITLE
Fix z velocity in shortrod NekRS model

### DIFF
--- a/tests/singlerod/short/nekrs/rod_short.oudf
+++ b/tests/singlerod/short/nekrs/rod_short.oudf
@@ -3,7 +3,7 @@ void insVelocityDirichletConditions3D(bcData* bc)
 {
   bc->uP = 0.0;
   bc->vP = 0.0;
-  bc->wP = 25.0;
+  bc->wP = 50.0;
 }
 
 void cdsDirichletConditions3D(bcData* bc)

--- a/tests/singlerod/short/nekrs/rod_short.usr
+++ b/tests/singlerod/short/nekrs/rod_short.usr
@@ -92,25 +92,6 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
-      subroutine userbc (ix,iy,iz,iside,ieg)
-      include 'SIZE'
-      include 'TOTAL'
-      include 'NEKUSE'
-
-      integer e,ieg
-      real ucx, ucy, ucz, ucy_e, yy
-
-      e=gllel(ieg)
-
-      ux = 0.0
-      uy = 0.0
-      uz = 25.0
-      temp = 523.15
-      flux = 0.25 !flux_recon(ix,iy,iz,e) !flux_moose
-
-      return
-      end
-c-----------------------------------------------------------------------
       subroutine useric (ix,iy,iz,ieg)
       include 'SIZE'
       include 'TOTAL'
@@ -123,7 +104,7 @@ c-----------------------------------------------------------------------
       if (idum.eq.0) idum = 99 + nid
       eps = .35
 
-      uz=25.0
+      uz=50.0
       uy=0.0
       ux=0.0
       temp=523.15


### PR DESCRIPTION
As discussed a few times in calls, the z velocity in the shortrod model should be 50 cm/s, not 25 cm/s. I've also removed the `userbc` routine that is superseded by the oudf file.