### PR TITLE
Use cells rather than cell handles in Shift calls.

### DIFF
--- a/include/enrico/shift_driver.h
+++ b/include/enrico/shift_driver.h
@@ -38,41 +38,41 @@ public:
   std::vector<CellHandle> find(const std::vector<Position>& positions) override;
 
   //! Set the density of the material in a cell
-  //! \param cell Handle to a cell
+  //! \param handle Handle to a cell
   //! \param rho Density in [g/cm^3]
-  void set_density(CellHandle cell, double rho) const override;
+  void set_density(CellHandle handle, double rho) const override;
 
   //! Set the temperature of a cell
-  //! \param cell Handle to a cell
+  //! \param handle Handle to a cell
   //! \param T Temperature in [K]
-  void set_temperature(CellHandle cell, double T) const override;
+  void set_temperature(CellHandle handle, double T) const override;
 
   //! Get the density of a cell
-  //! \param cell Handle to a cell
+  //! \param handle Handle to a cell
   //! \return Cell density in [g/cm^3]
-  double get_density(CellHandle cell) const override;
+  double get_density(CellHandle handle) const override;
 
   //! Get the temperature of a cell
-  //! \param cell Handle to a cell
+  //! \param handle Handle to a cell
   //! \return Temperature in [K]
-  double get_temperature(CellHandle cell) const override;
+  double get_temperature(CellHandle handle) const override;
 
   //! Get the volume of a cell
-  //! \param cell Handle to a cell
+  //! \param handle Handle to a cell
   //! \return Volume in [cm^3]
-  double get_volume(CellHandle cell) const override;
+  double get_volume(CellHandle handle) const override;
 
   //! Detemrine whether a cell contains fissionable nuclides
-  //! \param cell Handle to a cell
+  //! \param handle Handle to a cell
   //! \return Whether the cell contains fissionable nuclides
-  bool is_fissionable(CellHandle cell) const override;
+  bool is_fissionable(CellHandle handle) const override;
 
   std::size_t n_cells() const override { return num_cells_; }
 
   //! Create energy production tallies
   void create_tallies() override;
 
-  std::string cell_label(CellHandle cell) const override;
+  std::string cell_label(CellHandle handle) const override;
 
   //////////////////////////////////////////////////////////////////////////////
   // Driver interface

--- a/src/shift_driver.cpp
+++ b/src/shift_driver.cpp
@@ -105,41 +105,47 @@ void ShiftDriver::create_tallies()
   power_pl->set("union_lengths", counts);
 }
 
-void ShiftDriver::set_density(CellHandle cell, double rho) const
+void ShiftDriver::set_density(CellHandle handle, double rho) const
 {
   Expects(rho > 0);
+  auto cell = cells_.at(handle);
   Expects(cell >= 0 && cell < this->n_cells());
   int matid = geometry_->matid(cell);
   driver_->compositions()[matid]->set_density(rho);
 }
 
-void ShiftDriver::set_temperature(CellHandle cell, double T) const
+void ShiftDriver::set_temperature(CellHandle handle, double T) const
 {
   Expects(T > 0);
+  auto cell = cells_.at(handle);
   Expects(cell >= 0 && cell < this->n_cells());
   int matid = geometry_->matid(cell);
   driver_->compositions()[matid]->set_temperature(T);
 }
 
-double ShiftDriver::get_density(CellHandle cell) const
+double ShiftDriver::get_density(CellHandle handle) const
 {
+  auto cell = cells_.at(handle);
   int matid = geometry_->matid(cell);
   return driver_->compositions()[matid]->density();
 }
 
-double ShiftDriver::get_temperature(CellHandle cell) const
+double ShiftDriver::get_temperature(CellHandle handle) const
 {
+  auto cell = cells_.at(handle);
   int matid = geometry_->matid(cell);
   return driver_->compositions()[matid]->temperature();
 }
 
-double ShiftDriver::get_volume(CellHandle cell) const
+double ShiftDriver::get_volume(CellHandle handle) const
 {
+  auto cell = cells_.at(handle);
   return geometry_->cell_volume(cell);
 }
 
-bool ShiftDriver::is_fissionable(CellHandle cell) const
+bool ShiftDriver::is_fissionable(CellHandle handle) const
 {
+  auto cell = cells_.at(handle);
   int matid = geometry_->matid(cell);
   return driver_->compositions()[matid]->is_fissionable();
 }
@@ -190,9 +196,9 @@ xt::xtensor<double, 1> ShiftDriver::heat_source(double power) const
   return heat;
 }
 
-std::string ShiftDriver::cell_label(CellHandle cell) const
+std::string ShiftDriver::cell_label(CellHandle handle) const
 {
-  return std::to_string(cells_.at(cell));
+  return std::to_string(cells_.at(handle));
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Corrects use of cell index in calls to Shift functions. The ENRICO cell handle was being passed instead of the Shift cell index. Also changes the variable names to reflect the distinction between handles and cell indices.