### PR TITLE
WIP: nekRS update 2021-02-15

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	branch = master
 [submodule "vendor/nekRS"]
 	path = vendor/nekRS
-	url = https://github.com/RonRahaman/nekRS.git
+	url = https://github.com/Nek5000/nekRS.git
 	branch = mesh_interface

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ if (USE_NEK5000)
     add_subdirectory(vendor/nek5000)
 elseif (USE_NEKRS)
     add_subdirectory(vendor/nekRS)
+    # TODO: An upstream fix to the NekRS CMakeLists should let us to omit this
+    include_directories(vendor/nekRS/src/lib)
 endif ()
 add_subdirectory(vendor/openmc)
 

--- a/include/enrico/nekrs_driver.h
+++ b/include/enrico/nekrs_driver.h
@@ -4,6 +4,7 @@
 #include "enrico/heat_fluids_driver.h"
 #include "mpi.h"
 #include "pugixml.hpp"
+#include "nrs.hpp"
 
 namespace enrico {
 class NekRSDriver : public HeatFluidsDriver {
@@ -55,8 +56,10 @@ private:
   const double* z_;
   const double* temperature_;
   const double* rho_cp_;
-  const long long* element_info_;
+  const int* element_info_;
   std::vector<double> mass_matrix_;
+
+  nrs_t* nrs_ptr_;
 
   void* lib_udf_handle_;
   // TODO: Get cache dir from env.  See udfLoadFunction in nekrs/udf/udf.cpp

--- a/tests/singlerod/short/nekrs/rod_short.oudf
+++ b/tests/singlerod/short/nekrs/rod_short.oudf
@@ -1,14 +1,14 @@
 // Boundary conditions
-void insVelocityDirichletConditions3D(bcData* bc)
+void velocityDirichletConditions(bcData* bc)
 {
-  bc->uP = 0.0;
-  bc->vP = 0.0;
-  bc->wP = 50.0;
+  bc->u = 0.0;
+  bc->v = 0.0;
+  bc->w = 50.0;
 }
 
-void cdsDirichletConditions3D(bcData* bc)
+void scalarDirichletConditions(bcData* bc)
 {
-  bc->sP = 523.15;
+  bc->s = 523.15;
 }
 
 @kernel void cFill(const dlong Nelements,

--- a/tests/singlerod/short/nekrs/rod_short.udf
+++ b/tests/singlerod/short/nekrs/rod_short.udf
@@ -14,21 +14,22 @@ static occa::kernel cFillKernel;
 static occa::kernel cCopyKernel;
 static int updateProperties = 1;
 
-void userq(ins_t* ins, dfloat time, occa::memory o_S, occa::memory o_FS)
+void userq(nrs_t* nrs, dfloat time, occa::memory o_S, occa::memory o_FS)
 {
-  auto mesh = ins->cds->mesh;
+  auto mesh = nrs->cds->mesh;
+// ?????
   o_FS.copyFrom(localq.data(), mesh->Nelements * mesh->Np * sizeof(dfloat), 0);
 
 }
 
-void uservp(ins_t* ins,
+void uservp(nrs_t* nrs,
             dfloat time,
             occa::memory o_U,
             occa::memory o_S,
             occa::memory o_UProp,
             occa::memory o_SProp)
 {
-  cds_t* cds = ins->cds;
+  cds_t* cds = nrs->cds;
 
   if (updateProperties) {
     const dfloat rho = 1.0;
@@ -39,59 +40,63 @@ void uservp(ins_t* ins,
     const dfloat conSolid = 10 * conFluid;
 
     // velocity
-    const occa::memory o_mue = o_UProp.slice(0 * ins->fieldOffset * sizeof(dfloat));
-    const occa::memory o_rho = o_UProp.slice(1 * ins->fieldOffset * sizeof(dfloat));
-    cFillKernel(ins->mesh->Nelements, mue, 0, ins->o_elementInfo, o_mue);
-    cFillKernel(ins->mesh->Nelements, rho, 0, ins->o_elementInfo, o_rho);
+    const occa::memory o_mue = o_UProp.slice(0 * nrs->fieldOffset * sizeof(dfloat));
+    const occa::memory o_rho = o_UProp.slice(1 * nrs->fieldOffset * sizeof(dfloat));
+    cFillKernel(nrs->mesh->Nelements, mue, 0, nrs->mesh->o_elementInfo, o_mue);
+    cFillKernel(nrs->mesh->Nelements, rho, 0, nrs->mesh->o_elementInfo, o_rho);
     // temperature
     const occa::memory o_con = o_SProp.slice(0 * cds->fieldOffset * sizeof(dfloat));
     const occa::memory o_rhoCp = o_SProp.slice(1 * cds->fieldOffset * sizeof(dfloat));
 
+// ?????
     double* nekScratch = nekData.cbscnrs;
     o_SProp.copyFrom(nekScratch, cds->Nlocal * sizeof(dfloat), 0);
+
     cFillKernel(
-      cds->mesh->Nelements, rhoCpFluid, rhoCpSolid, ins->o_elementInfo, o_rhoCp);
+      cds->mesh->Nelements, rhoCpFluid, rhoCpSolid, nrs->mesh->o_elementInfo, o_rhoCp);
     updateProperties = 0;
   }
 }
 
 /* UDF Functions */
 
-void UDF_LoadKernels(ins_t* ins)
+void UDF_LoadKernels(nrs_t* nrs)
 {
-  cFillKernel = udfBuildKernel(ins, "cFill");
-  cCopyKernel = udfBuildKernel(ins, "cCopy");
+  cFillKernel = udfBuildKernel(nrs, "cFill");
+  cCopyKernel = udfBuildKernel(nrs, "cCopy");
 }
 
-void UDF_Setup(ins_t* ins)
+void UDF_Setup(nrs_t* nrs)
 {
-  // get IC from nek
-  if (!ins->readRestartFile)
-    nek_copyTo(ins->startTime);
-  ins->o_usrwrk.free();
-  free(ins->usrwrk);
-  ins->usrwrk = (dfloat*)calloc(ins->mesh->Nelements * ins->mesh->Np, sizeof(dfloat));
-  ins->o_usrwrk = ins->mesh->device.malloc(
-    ins->mesh->Nelements * ins->mesh->Np * sizeof(dfloat), ins->usrwrk);
+  // ?????
+  //// get IC from nek
+  //if (!nrs->readRestartFile)
+  //  nek_copyTo(nrs->startTime);
+
+  nrs->o_usrwrk.free();
+  free(nrs->usrwrk);
+  nrs->usrwrk = (dfloat*)calloc(nrs->mesh->Nelements * nrs->mesh->Np, sizeof(dfloat));
+  nrs->o_usrwrk = nrs->mesh->device.malloc(
+    nrs->mesh->Nelements * nrs->mesh->Np * sizeof(dfloat), nrs->usrwrk);
 
   nek_userchk();
   auto* wrk1 = nekData.cbscnrs;
-  ins->o_usrwrk.copyFrom(wrk1, ins->mesh->Nelements * ins->mesh->Np * sizeof(dfloat));
+  nrs->o_usrwrk.copyFrom(wrk1, nrs->mesh->Nelements * nrs->mesh->Np * sizeof(dfloat));
 
   udf.sEqnSource = &userq;
   udf.properties = &uservp;
 
   // ATTENTION: Need to explicitly resize localq
-  localq.resize(ins->cds->mesh->Nelements * ins->cds->mesh->Np);
+  localq.resize(nrs->cds->mesh->Nelements * nrs->cds->mesh->Np);
 }
 
-void UDF_ExecuteStep(ins_t* ins, dfloat time, int tstep)
+void UDF_ExecuteStep(nrs_t* nrs, dfloat time, int tstep)
 {
-  if (ins->isOutputStep) {
+  if (nrs->isOutputStep) {
     nek_ocopyFrom(time, tstep);
     nek_userchk();
     auto* wrk1 = nekData.cbscnrs;
-    ins->o_usrwrk.copyFrom(wrk1, ins->mesh->Nelements * ins->mesh->Np * sizeof(dfloat));
+    nrs->o_usrwrk.copyFrom(wrk1, nrs->mesh->Nelements * nrs->mesh->Np * sizeof(dfloat));
     updateProperties = 1;
   }
 }

--- a/tests/singlerod/short/nekrs/rod_short.udf
+++ b/tests/singlerod/short/nekrs/rod_short.udf
@@ -17,7 +17,6 @@ static int updateProperties = 1;
 void userq(nrs_t* nrs, dfloat time, occa::memory o_S, occa::memory o_FS)
 {
   auto mesh = nrs->cds->mesh;
-// ?????
   o_FS.copyFrom(localq.data(), mesh->Nelements * mesh->Np * sizeof(dfloat), 0);
 
 }
@@ -48,10 +47,10 @@ void uservp(nrs_t* nrs,
     const occa::memory o_con = o_SProp.slice(0 * cds->fieldOffset * sizeof(dfloat));
     const occa::memory o_rhoCp = o_SProp.slice(1 * cds->fieldOffset * sizeof(dfloat));
 
-// ?????
     double* nekScratch = nekData.cbscnrs;
     o_SProp.copyFrom(nekScratch, cds->Nlocal * sizeof(dfloat), 0);
 
+    cFillKernel(cds->mesh->Nelements, conFluid, conSolid, nrs->mesh->o_elementInfo, o_con);
     cFillKernel(
       cds->mesh->Nelements, rhoCpFluid, rhoCpSolid, nrs->mesh->o_elementInfo, o_rhoCp);
     updateProperties = 0;
@@ -68,11 +67,6 @@ void UDF_LoadKernels(nrs_t* nrs)
 
 void UDF_Setup(nrs_t* nrs)
 {
-  // ?????
-  //// get IC from nek
-  //if (!nrs->readRestartFile)
-  //  nek_copyTo(nrs->startTime);
-
   nrs->o_usrwrk.free();
   free(nrs->usrwrk);
   nrs->usrwrk = (dfloat*)calloc(nrs->mesh->Nelements * nrs->mesh->Np, sizeof(dfloat));
@@ -80,6 +74,7 @@ void UDF_Setup(nrs_t* nrs)
     nrs->mesh->Nelements * nrs->mesh->Np * sizeof(dfloat), nrs->usrwrk);
 
   nek_userchk();
+
   auto* wrk1 = nekData.cbscnrs;
   nrs->o_usrwrk.copyFrom(wrk1, nrs->mesh->Nelements * nrs->mesh->Np * sizeof(dfloat));
 


### PR DESCRIPTION
Diagnostic PR for upstream nekRS updates.  Currently, the coupled OpenMC/nekRS shortrod cases fail during nekRS solve:
```
step= 1  t= 1.00000000e-04  dt=1.0e-04  C= 4.84  UVW: 8  P: 18  S: 94  eTime= 4.31e-01, 4.31334e-01 s
step= 2  t= 2.00000000e-04  dt=1.0e-04  C= 31.02  UVW: 8  P: 24  S: 57  eTime= 4.18e-01, 8.49406e-01 s
Unreasonable CFL! Dying ...
```

In a standalone nekRS, the shortrod problem has similar results:
```
step= 1  t= 1.00000000e-04  dt=1.0e-04  C= 4.84  UVW: 8  P: 18  S: 1  eTime= 2.33e-01, 2.33210e-01 s
step= 2  t= 2.00000000e-04  dt=1.0e-04  C= 31.02  UVW: 8  P: 24  S: 1  eTime= 2.92e-01, 5.24758e-01 s
Unreasonable CFL! Dying ...
```