### PR TITLE
MPICH_FC in GitLab CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
   MPI_DIR: /usr
   OMP_NUM_THREADS: 2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  MPICH_FC: gfortran
 
 jobs:
   main:


### PR DESCRIPTION
The `ubuntu-latest` in the GitLab CI runners have swtiched from Ubuntu 18 to 20.  The MPICH distribution in Ubuntu 20 requires the evn variable `MPICH_FC=gfortran` to configure Nek5000 properly.  This PR adds that env variable.