### PR TITLE
WIP: Update cell density based on cell-avg'ed temperature

### DIFF
--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -49,12 +49,7 @@ public:
   //! Update the temperature for the neutronics solver
   //!
   //! \param relax Apply relaxation to temperature before updating neutronics solver
-  void update_temperature(bool relax);
-
-  //! Update the density for the neutronics solver
-  //!
-  //! \param relax Apply relaxation to density before updating neutronics solver
-  void update_density(bool relax);
+  void update_temperature_and_density(bool relax);
 
   //! Check convergence of the coupled solve for the current Picard iteration.
   bool is_converged();
@@ -169,15 +164,6 @@ private:
   xt::xtensor<double, 1> temperatures_;
 
   xt::xtensor<double, 1> temperatures_prev_; //!< Previous Picard iteration temperature
-
-  //! Current Picard iteration density; this density is the density
-  //! computed by the thermal-hydraulic solver, and data mappings may result in
-  //! a different density actually used in the neutronics solver. For example,
-  //! the entries in this xtensor may be averaged over neutronics cells to give
-  //! the density used by the neutronics solver.
-  xt::xtensor<double, 1> densities_;
-
-  xt::xtensor<double, 1> densities_prev_; //!< Previous Picard iteration density
 
   //! Current Picard iteration heat source; this heat source is the heat source
   //! computed by the neutronics solver, and data mappings may result in a different


### PR DESCRIPTION
In this PR, the `CoupledDriver` computes cell density from cell-averaged temperature and the heat/fluid solver's pressure BC using the IAPWS correlation.  

I'm marking this as "WIP" because, even though it's reasonable for Nek, it might not be appropriate for the heat surrogate.  The `SurrogateDriver` solves for enthalpy H in fluid; then it computes T from pressure P and H using the IAPWS correlation.   Seems odd to compute rho using a second correlation with T and P.  Seems like it would be better to directly calculate rho based on T and H.  But currently, the base class `HeatFluids` driver doesn't expose H to the `CoupledDriver`.  

Given that we eventually want to do enthalpy coupling for all the head/fluids solvers, we might not want to merge this PR.  I'm just creating the PR in case @emerzari and @hapfang want to use this for testing.  