### PR TITLE
Remove wrong barrier in NekRSDriver

### DIFF
--- a/src/nekrs_driver.cpp
+++ b/src/nekrs_driver.cpp
@@ -76,7 +76,6 @@ NekRSDriver::NekRSDriver(MPI_Comm comm, pugi::xml_node node)
 
     init_displs();
   }
-  comm_.Barrier();
 }
 
 void NekRSDriver::init_step()


### PR DESCRIPTION
This removes an incorrect barrier in `NekRSDriver`.   It fixes coupled neutronics/nekRS runs with disjoint communicators.  

The nekRS driver's comm was passed to the barrier function.  However, the barrier function is called by all the ranks in the coupled driver's comm, including the ranks that are not active in the nekRS driver's comm.  In runs with disjoint comms, this causes MPI errors due to an invalid comm in the `MPI_Barrier` call.  