### PR TITLE
Verbosity setting for coupled driver

### DIFF
--- a/doc/source/userguide/input.rst
+++ b/doc/source/userguide/input.rst
@@ -110,7 +110,7 @@ Base node for coupling parameters
 ``<verbose>``
 -----------
 
-A boolean ("true" or "false", default "false).  If true, print detailed info, including
+A boolean ("true" or "false", default "false").  If true, print detailed info, including
 MPI communicator layouts for each rank and volume comparisons for each cell (summarized
 volume statistics are always printed).
 

--- a/doc/source/userguide/input.rst
+++ b/doc/source/userguide/input.rst
@@ -107,6 +107,13 @@ Under the ``<neutronics>`` element, these Shift-specific sub-elements are availa
 
 Base node for coupling parameters
 
+``<verbose>``
+-----------
+
+A boolean ("true" or "false", default "false).  If true, print detailed info, including
+MPI communicator layouts for each rank and volume comparisons for each cell (summarized
+volume statistics are always printed).
+
 ``<power>``
 -----------
 

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -206,9 +206,9 @@ public:
 
   //! Displays a message from rank 0
   //! \param A message to display
-  void message(const std::string& msg) const
+  void message(const std::string& msg, int rank = 0) const
   {
-    if (rank == 0)
+    if (this->rank == rank)
       std::cout << "[ENRICO]: " << msg << std::endl;
   }
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -214,6 +214,9 @@ private:
 
   // Norm to use for convergence checks
   Norm norm_{Norm::LINF};
+
+  // Print verbose output
+  bool verbose_ = false;
 };
 
 } // namespace enrico


### PR DESCRIPTION
This adds a verbosity setting for the `CoupledDriver`.  

Verbosity is "false" by default.  If "false", this output is suppressed:
* Communicator layout for each rank
* Volume comparisons for each neutronics cell
If "true", those outputs are shown (as in the current master branch).   

Summary statistics for the volume comparisons are always printed (this is a new feature).  For each cell, the relative difference between the neutronics driver's volume and the volume accumulated from heat/fluids elements is calculated.  Then the min, max, and mean of the relative differences are reported.  
