### PR TITLE
Write properties file at each iteration when using OpenMC 

### DIFF
--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -6,6 +6,7 @@
 #include "openmc/capi.h"
 #include "openmc/cell.h"
 #include "openmc/constants.h"
+#include "openmc/summary.h"
 #include "openmc/tallies/filter.h"
 #include "openmc/tallies/filter_material.h"
 #include "openmc/tallies/tally.h"
@@ -208,9 +209,13 @@ void OpenmcDriver::solve_step()
 void OpenmcDriver::write_step(int timestep, int iteration)
 {
   timer_write_step.start();
-  std::string filename{"openmc_t" + std::to_string(timestep) + "_i" +
-                       std::to_string(iteration) + ".h5"};
+  std::string suffix{"_t" + std::to_string(timestep) + "_i" + std::to_string(iteration) +
+                     ".h5"};
+  std::string filename{"openmc" + suffix};
   err_chk(openmc_statepoint_write(filename.c_str(), nullptr));
+
+  std::string prop_file{"properties" + suffix};
+  err_chk(openmc_properties_export(prop_file.c_str()));
   timer_write_step.stop();
 }
 

--- a/tests/singlerod/long/openmc/geometry.xml
+++ b/tests/singlerod/long/openmc/geometry.xml
@@ -38,403 +38,403 @@
     <dimension>1 1 200</dimension>
     <lower_left>-0.63 -0.63 0.0</lower_left>
     <universes>
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
 1 </universes>
   </lattice>
@@ -447,10 +447,10 @@
   <surface coeffs="0.0 0.0 0.475" id="7" type="z-cylinder" />
   <surface coeffs="0.0" id="8" type="x-plane" />
   <surface coeffs="0.0" id="9" type="y-plane" />
-  <surface boundary="periodic" coeffs="-0.63" id="10" type="x-plane" />
-  <surface boundary="periodic" coeffs="0.63" id="11" type="x-plane" />
-  <surface boundary="periodic" coeffs="-0.63" id="12" type="y-plane" />
-  <surface boundary="periodic" coeffs="0.63" id="13" type="y-plane" />
+  <surface boundary="periodic" coeffs="-0.63" id="10" periodic_surface_id="11" type="x-plane" />
+  <surface boundary="periodic" coeffs="0.63" id="11" periodic_surface_id="10" type="x-plane" />
+  <surface boundary="periodic" coeffs="-0.63" id="12" periodic_surface_id="13" type="y-plane" />
+  <surface boundary="periodic" coeffs="0.63" id="13" periodic_surface_id="12" type="y-plane" />
   <surface boundary="vacuum" coeffs="0.0" id="14" type="z-plane" />
   <surface boundary="vacuum" coeffs="200.0" id="15" type="z-plane" />
 </geometry>

--- a/tests/singlerod/short/openmc/geometry.xml
+++ b/tests/singlerod/short/openmc/geometry.xml
@@ -38,23 +38,23 @@
     <dimension>1 1 10</dimension>
     <lower_left>-0.63 -0.63 0.0</lower_left>
     <universes>
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
-1 
+1
 
 1 </universes>
   </lattice>
@@ -67,10 +67,10 @@
   <surface coeffs="0.0 0.0 0.475" id="7" type="z-cylinder" />
   <surface coeffs="0.0" id="8" type="x-plane" />
   <surface coeffs="0.0" id="9" type="y-plane" />
-  <surface boundary="periodic" coeffs="-0.63" id="10" type="x-plane" />
-  <surface boundary="periodic" coeffs="0.63" id="11" type="x-plane" />
-  <surface boundary="periodic" coeffs="-0.63" id="12" type="y-plane" />
-  <surface boundary="periodic" coeffs="0.63" id="13" type="y-plane" />
+  <surface boundary="periodic" coeffs="-0.63" id="10" periodic_surface_id="11" type="x-plane" />
+  <surface boundary="periodic" coeffs="0.63" id="11" periodic_surface_id="10" type="x-plane" />
+  <surface boundary="periodic" coeffs="-0.63" id="12" periodic_surface_id="13" type="y-plane" />
+  <surface boundary="periodic" coeffs="0.63" id="13" periodic_surface_id="12" type="y-plane" />
   <surface boundary="reflective" coeffs="0.0" id="14" type="z-plane" />
   <surface boundary="reflective" coeffs="10.0" id="15" type="z-plane" />
 </geometry>


### PR DESCRIPTION
OpenMC now has the ability to write a "properties" file which includes temperature/density information (openmc-dev/openmc#1852). This PR updates the OpenMC submodule and changes `OpenmcDriver::write_step` to write a properties file for each iteration. Along with proposed changes in [openmc-plotter](https://github.com/openmc-dev/plotter/pull/63), this allows us to easily visualize temperature/density distributions (on OpenMC's geometry).

With the OpenMC update, I also needed to modify the geometry.xml files for the short/long rod tests to include more information for periodic boundary conditions.