### PR TITLE
Toggle num threads before single-physics driver execute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,8 +198,14 @@ elseif (USE_NEKRS)
 endif ()
 
 if (SCALE_FOUND)
-  target_compile_definitions(libenrico PRIVATE USE_SHIFT)
-  list(APPEND LIBRARIES ${SCALE_LIBRARIES} ${SCALE_TPL_LIBRARIES})
+    target_compile_definitions(libenrico PRIVATE USE_SHIFT)
+    list(APPEND LIBRARIES ${SCALE_LIBRARIES} ${SCALE_TPL_LIBRARIES})
+endif ()
+
+# Discover OpenMP.  Needed for CoupledDriver to discover number of threads
+find_package(OpenMP)
+if (OPENMP_CXX_FOUND)
+    list(APPEND LIBRARIES OpenMP::OpenMP_CXX)
 endif ()
 
 target_link_libraries(libenrico PUBLIC ${LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.9)
 project(enrico Fortran C CXX)
 
 #===============================================================================

--- a/include/enrico/driver.h
+++ b/include/enrico/driver.h
@@ -55,6 +55,9 @@ public:
   Timer timer_solve_step;    //!< For the solve_step() member function
   Timer timer_write_step;    //!< For the write_step() member function
   Timer timer_finalize_step; //!< For the finalize_step() member function
+
+  //! Number of OpenMP threads. Initialized if OpenMP is used.
+  int num_threads = -1;
 };
 
 } // namespace enrico

--- a/include/enrico/driver.h
+++ b/include/enrico/driver.h
@@ -11,6 +11,10 @@
 
 #include <vector>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 namespace enrico {
 
 //! Base class for driver that controls a physics solve
@@ -25,7 +29,13 @@ public:
     , timer_solve_step(comm_)
     , timer_write_step(comm_)
     , timer_finalize_step(comm_)
-  {}
+  {
+#ifdef _OPENMP
+#pragma omp parallel default(none) shared(num_threads)
+#pragma omp single
+    num_threads = omp_get_num_threads();
+#endif
+  }
 
   //! Performs the necessary initialization for this solver in one Picard iteration
   virtual void init_step() {}
@@ -56,8 +66,8 @@ public:
   Timer timer_write_step;    //!< For the write_step() member function
   Timer timer_finalize_step; //!< For the finalize_step() member function
 
-  //! Number of OpenMP threads. Initialized if OpenMP is used.
-  int num_threads = -1;
+  //! Number of OpenMP threads
+  int num_threads;
 };
 
 } // namespace enrico

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -35,10 +35,6 @@
 #include <unistd.h>
 #endif
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 namespace enrico {
 
 CoupledDriver::CoupledDriver(MPI_Comm comm, pugi::xml_node node)

--- a/src/nekrs_driver.cpp
+++ b/src/nekrs_driver.cpp
@@ -12,10 +12,6 @@
 #include <algorithm>
 #include <dlfcn.h>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 namespace enrico {
 NekRSDriver::NekRSDriver(MPI_Comm comm, pugi::xml_node node)
   : HeatFluidsDriver(comm, node)

--- a/src/nekrs_driver.cpp
+++ b/src/nekrs_driver.cpp
@@ -12,6 +12,10 @@
 #include <algorithm>
 #include <dlfcn.h>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 namespace enrico {
 NekRSDriver::NekRSDriver(MPI_Comm comm, pugi::xml_node node)
   : HeatFluidsDriver(comm, node)
@@ -83,6 +87,13 @@ NekRSDriver::NekRSDriver(MPI_Comm comm, pugi::xml_node node)
 
     init_displs();
   }
+
+#ifdef _OPENMP
+#pragma omp parallel default(none) shared(num_threads)
+#pragma omp single
+  num_threads = omp_get_num_threads();
+#endif
+
   timer_driver_setup.stop();
 }
 

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -18,10 +18,6 @@
 #include <string>
 #include <unordered_map>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 namespace enrico {
 
 OpenmcDriver::OpenmcDriver(MPI_Comm comm)

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -18,6 +18,10 @@
 #include <string>
 #include <unordered_map>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 namespace enrico {
 
 OpenmcDriver::OpenmcDriver(MPI_Comm comm)
@@ -53,6 +57,13 @@ OpenmcDriver::OpenmcDriver(MPI_Comm comm)
       }
     }
   }
+
+#ifdef _OPENMP
+#pragma omp parallel default(none) shared(num_threads)
+#pragma omp single
+  num_threads = omp_get_num_threads();
+#endif
+
   timer_driver_setup.stop();
 }
 

--- a/src/shift_driver.cpp
+++ b/src/shift_driver.cpp
@@ -9,10 +9,6 @@
 
 #include <unordered_map>
 
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 namespace enrico {
 
 ShiftDriver::ShiftDriver(MPI_Comm comm, pugi::xml_node node)

--- a/src/shift_driver.cpp
+++ b/src/shift_driver.cpp
@@ -9,6 +9,10 @@
 
 #include <unordered_map>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 namespace enrico {
 
 ShiftDriver::ShiftDriver(MPI_Comm comm, pugi::xml_node node)
@@ -53,6 +57,13 @@ ShiftDriver::ShiftDriver(MPI_Comm comm, pugi::xml_node node)
     num_cells_ = geometry_->num_cells();
   }
   MPI_Barrier(MPI_COMM_WORLD);
+
+#ifdef _OPENMP
+#pragma omp parallel default(none) shared(num_threads)
+#pragma omp single
+  num_threads = omp_get_num_threads();
+#endif
+
   timer_driver_setup.stop();
 }
 


### PR DESCRIPTION
This is a workaround for the fact that nekRS forces the number of OpenMP threads to be 1:

https://github.com/Nek5000/nekRS/blob/d955b9b75cf50ca525dfc2f9c5a38e8c622e5d59/src/core/utils/occaHelpers.cpp#L92-L93 

The nekRS devs confirmed that this will be removed in upcoming versions.  At that point, we should be able to revert this PR.

In this PR:
* Each single-physics driver discovers the number of OpenMP threads at the end of its constructor.  It sets the num threads to a data member, `num_threads`
* In the coupled driver, the number of threads is toggled directly before each single-physics driver executes.  