### PR TITLE
Fix docs (image and doxygen output paths)

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_BRIEF          = "Exascale Nuclear Reactor Investigative COde"
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = "doc/img/ecp-logo-small.png"
+PROJECT_LOGO           = "doc/source/img/ecp-logo-small.png"
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,8 +74,8 @@ def build_doxygen(app):
 
     # XML goes in Sphinx source dir, and HTML goes in Sphinx output dir
 
-    doxygen_xmldir = path.abspath(path.join(app.srcdir, 'doxygen', 'xml'))
-    doxygen_htmldir = path.abspath(path.join(app.outdir, 'doxygen', 'html'))
+    doxygen_xmldir = path.abspath(path.join(app.srcdir, 'devguide', 'doxygen', 'xml'))
+    doxygen_htmldir = path.abspath(path.join(app.outdir, 'devguide', 'doxygen', 'html'))
 
     # Doxygen won't create *nested* output dirs, so we do it ourselves.
 


### PR DESCRIPTION
A few fixes to paths in the documentation:
* Input dir for the ECP logo
* Output dir for generated Doxygen HTML
I think the last time I reorganized the doc files, I forgot to update these paths.  