### PR TITLE
pin docutils version for readthdocs.io

### DIFF
--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,2 +1,6 @@
 astropy-sphinx-theme
 sphinxcontrib-katex
+
+# 2021-11-03 - Need to pin docutils version for readthedocs.io
+# See https://github.com/readthedocs/readthedocs.org/issues/8616
+docutils < 0.18


### PR DESCRIPTION
The recent version of docutils, v18.0, is not compatible with readthdocs builds.  See:  https://github.com/readthedocs/readthedocs.org/issues/8616

This PR pins the version of docutils to < 18.0