### PR TITLE
Implementation of Boron Driver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.configureOnOpen": false
-}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ target_link_libraries(heat_xfer PUBLIC iapws)
 # =============================================================================
 
 set(SOURCES
+    src/boron_driver.cpp
     src/coupled_driver.cpp
     src/comm_split.cpp
     src/surrogate_heat_driver.cpp
@@ -261,13 +262,13 @@ set_target_properties(unittests PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
 # Install targets
 #################################################################################
 
-set(INSTALL_TARGETS 
-  enrico 
-  libenrico 
-  iapws 
-  heat_xfer 
-  Catch 
-  unittests 
+set(INSTALL_TARGETS
+  enrico
+  libenrico
+  iapws
+  heat_xfer
+  Catch
+  unittests
   comm_split_demo
   test_openmc_singlerod)
 

--- a/doc/source/userguide/input.rst
+++ b/doc/source/userguide/input.rst
@@ -1,6 +1,6 @@
 .. _userguide_input:
 
-ENRICO Runtime Settings 
+ENRICO Runtime Settings
 =======================
 
 Parameters and settings for each individual physics code are set normally in
@@ -95,12 +95,49 @@ Base element for neutron transport driver parameters
 The physics driver for solving particle transport. Valid options are "openmc",
 "shift", and "surrogate".
 
+``<boron_search>``
+------------------
+
+A boolean (“true” or “false”, default “false”). If true, then a Boron search to
+the ``target_keff`` value will be performed. If false, no Boron search will be
+performed. This Boron search yields the Boron parts per million (ppm) on a
+number density basis in the fluid-bearing regions of the model.
+
 Shift-specific Parameters
 -------------------------
 
 Under the ``<neutronics>`` element, these Shift-specific sub-elements are available:
 
 * ``<filename>``: Path to the Shift XML input file
+
+Boron search-specific Parameters
+--------------------------------
+
+Under the ``<neutronics>`` element, these Boron search-specific sub-elements are
+available:
+
+* ``<initial_boron_ppm>``: The first guess of the fluid's Boron concentration
+to use when performing the critical search. This parameter is provided in units
+of parts-per-million Boron on a number-density basis. If not provided, this
+defaults to the concentration present in the neutron transport driver's initial
+model.
+* ``<target_keff>``: The k-eigenvalue to search for by varing the boron ppm.
+This defaults to a value of 1.0.
+* ``<target_keff_tolerance>``: The tolerance on the k-eigenvalue, to a 95%
+confidence interval based on the stochastic variation of k-eff, that will be
+used to evaluate convergence of the boron search. This defaults to a value of
+1.0e-3.
+* ``<B10_enrichment>``: The enrichment of B-10 in the Boron in terms of an atom
+fraction. This defaults to a value of 0.1982.
+* ``<boron_epsilon>``: The target Boron search convergence criterion. If
+:math:`ppm_i` and :math:`pppm_{i+1}` are the set of total Boron number density
+concentrations (on a number density basis) at iterations :math:`i` and
+:math:`i+1`, convergence is reached if
+
+.. math::
+    \lvert ppm_{i+1} - ppm_i \rvert < \epsilon
+
+This defaults to a value of 1.0e-3.
 
 ``<coupling>``
 ~~~~~~~~~~~~~~

--- a/doc/source/userguide/input.rst
+++ b/doc/source/userguide/input.rst
@@ -145,8 +145,8 @@ available:
 .. note:: In ENRICO, the Boron parts-per-million (ppm) is defined as the ppm
           Boron on a number-density basis.
 
-.. note:: ENRICO assumes that the reactivity effect of the H and O in boric acid
-          is small and on the order of the Hydrogen and Oxygen number density
+.. note:: ENRICO assumes that the reactivity effect of the Hydrogen and Oxygen
+          in boric acid is small and on the order of their number density
           variations in water. Therefore, the ENRICO's Boron search only
           modifies the Boron concentrations and not the Hydrogen and Oxygen as
           the Boron ppm varies.

--- a/doc/source/userguide/input.rst
+++ b/doc/source/userguide/input.rst
@@ -98,9 +98,9 @@ The physics driver for solving particle transport. Valid options are "openmc",
 ``<boron_search>``
 ------------------
 
-A boolean (“true” or “false”, default “false”). If true, then a Boron search to
-the ``target_keff`` value will be performed. If false, no Boron search will be
-performed. This Boron search yields the Boron parts per million (ppm) on a
+A boolean (“true” or “false”, default “false”). If true, then a boron search to
+the ``target_keff`` value will be performed. If false, no boron search will be
+performed. This boron search yields the boron parts per million (ppm) on a
 number density basis in the fluid-bearing regions of the model.
 
 Shift-specific Parameters
@@ -113,12 +113,12 @@ Under the ``<neutronics>`` element, these Shift-specific sub-elements are availa
 Boron search-specific Parameters
 --------------------------------
 
-Under the ``<neutronics>`` element, these Boron search-specific sub-elements are
+Under the ``<neutronics>`` element, these boron search-specific sub-elements are
 available:
 
-* ``<initial_boron_ppm>``: The first guess of the fluid's Boron concentration
+* ``<initial_boron_ppm>``: The first guess of the fluid's boron concentration
   in units of ppm to use when performing the critical search. If not provided,
-  this defaults to the average Boron ppm across all fluid-bearing cells of the
+  this defaults to the average boron ppm across all fluid-bearing cells of the
   initial the neutron transport model.
 * ``<target_keff>``: The k-eigenvalue to search for by varing the boron ppm.
   This defaults to a value of 1.0.
@@ -126,30 +126,30 @@ available:
   confidence interval based on the stochastic variation of k-eff, that will be
   used to evaluate convergence of the boron search. This defaults to a value of
   1.0e-3.
-* ``<B10_enrichment>``: The enrichment of B-10 in the Boron in terms of an atom
+* ``<B10_enrichment>``: The enrichment of B-10 in the boron in terms of an atom
   fraction. This defaults to a value of 0.1982.
-* ``<boron_epsilon>``: The target Boron search convergence criterion. If
-  :math:`ppm_i` and :math:`ppm_{i+1}` are the set of total Boron number
+* ``<boron_epsilon>``: The target boron search convergence criterion. If
+  :math:`ppm_i` and :math:`ppm_{i+1}` are the set of total boron number
   density concentrations (on a number density basis) at iterations :math:`i`
   and :math:`i+1`, convergence is reached if both of the following conditions
   are achieved:
 
-.. math::
-    \lvert ppm_{i+1} - ppm_i \rvert < \epsilon_{boron}
+  .. math::
+      \lvert ppm_{i+1} - ppm_i \rvert < \epsilon_{boron}
 
-.. math::
-    \lvert k_{eff,i+1} - k_{eff,i} \rvert < \epsilon_{keff}
+  .. math::
+      \lvert k_{eff,i+1} - k_{eff,i} \rvert < \epsilon_{keff}
 
   This defaults to a value of 1.0e-3.
 
-.. note:: In ENRICO, the Boron parts-per-million (ppm) is defined as the ppm
-          Boron on a number-density basis.
+.. note:: In ENRICO, the boron parts-per-million (ppm) is defined as the ppm
+          boron on a number-density basis.
 
-.. note:: ENRICO assumes that the reactivity effect of the Hydrogen and Oxygen
+.. note:: ENRICO assumes that the reactivity effect of the hydrogen and oxygen
           in boric acid is small and on the order of their number density
-          variations in water. Therefore, the ENRICO's Boron search only
-          modifies the Boron concentrations and not the Hydrogen and Oxygen as
-          the Boron ppm varies.
+          variations in water. Therefore, the ENRICO's boron search only
+          modifies the boron concentrations and not the hydrogen and oxygen as
+          the boron ppm varies.
 
 ``<coupling>``
 ~~~~~~~~~~~~~~

--- a/doc/source/userguide/input.rst
+++ b/doc/source/userguide/input.rst
@@ -117,27 +117,38 @@ Under the ``<neutronics>`` element, these Boron search-specific sub-elements are
 available:
 
 * ``<initial_boron_ppm>``: The first guess of the fluid's Boron concentration
-to use when performing the critical search. This parameter is provided in units
-of parts-per-million Boron on a number-density basis. If not provided, this
-defaults to the concentration present in the neutron transport driver's initial
-model.
+  in units of ppm to use when performing the critical search. If not provided,
+  this defaults to the average Boron ppm across all fluid-bearing cells of the
+  initial the neutron transport model.
 * ``<target_keff>``: The k-eigenvalue to search for by varing the boron ppm.
-This defaults to a value of 1.0.
+  This defaults to a value of 1.0.
 * ``<target_keff_tolerance>``: The tolerance on the k-eigenvalue, to a 95%
-confidence interval based on the stochastic variation of k-eff, that will be
-used to evaluate convergence of the boron search. This defaults to a value of
-1.0e-3.
+  confidence interval based on the stochastic variation of k-eff, that will be
+  used to evaluate convergence of the boron search. This defaults to a value of
+  1.0e-3.
 * ``<B10_enrichment>``: The enrichment of B-10 in the Boron in terms of an atom
-fraction. This defaults to a value of 0.1982.
+  fraction. This defaults to a value of 0.1982.
 * ``<boron_epsilon>``: The target Boron search convergence criterion. If
-:math:`ppm_i` and :math:`pppm_{i+1}` are the set of total Boron number density
-concentrations (on a number density basis) at iterations :math:`i` and
-:math:`i+1`, convergence is reached if
+  :math:`ppm_i` and :math:`ppm_{i+1}` are the set of total Boron number
+  density concentrations (on a number density basis) at iterations :math:`i`
+  and :math:`i+1`, convergence is reached if both of the following conditions
+  are achieved:
 
 .. math::
-    \lvert ppm_{i+1} - ppm_i \rvert < \epsilon
+    \lvert ppm_{i+1} - ppm_i \rvert < \epsilon_{boron}
 
-This defaults to a value of 1.0e-3.
+.. math::
+    \lvert k_{eff,i+1} - k_{eff,i} \rvert < \epsilon_{keff}
+
+  This defaults to a value of 1.0e-3.
+
+.. note:: In ENRICO, the Boron parts-per-million (ppm) is defined as the ppm
+          Boron on a number-density basis.
+
+.. note:: ENRICO assumes that the reactivity effect of the H and O in boric acid
+          is small and on the order of the H and O number density variations in
+          water. Therefore, the ENRICO's Boron search only modifies the Boron
+          concentrations and not the H and O as the Boron ppm varies.
 
 ``<coupling>``
 ~~~~~~~~~~~~~~

--- a/doc/source/userguide/input.rst
+++ b/doc/source/userguide/input.rst
@@ -146,9 +146,10 @@ available:
           Boron on a number-density basis.
 
 .. note:: ENRICO assumes that the reactivity effect of the H and O in boric acid
-          is small and on the order of the H and O number density variations in
-          water. Therefore, the ENRICO's Boron search only modifies the Boron
-          concentrations and not the H and O as the Boron ppm varies.
+          is small and on the order of the Hydrogen and Oxygen number density
+          variations in water. Therefore, the ENRICO's Boron search only
+          modifies the Boron concentrations and not the Hydrogen and Oxygen as
+          the Boron ppm varies.
 
 ``<coupling>``
 ~~~~~~~~~~~~~~

--- a/include/enrico/boron_driver.h
+++ b/include/enrico/boron_driver.h
@@ -1,0 +1,50 @@
+//! \file boron_driver.h
+//! Base class for boron criticality search
+#ifndef BORON_DRIVER_H
+#define BORON_DRIVER_H
+
+#include "enrico/driver.h"
+
+namespace enrico {
+class BoronDriver : public Driver {
+public:
+  explicit BoronDriver(MPI_Comm comm);
+
+  ~BoronDriver();
+
+  //! Gets the water density of the borated water
+  //! \return Water density in [g/cm^3]
+  void set_H2O_density(double H2Odens);
+
+  //! Sets the current and previous keff in the boron driver class
+  //! \param keff is the current k-effective after the Openmc run
+  //! \param keffprev is the previous k-effective
+  void set_k_effective(double keff, double keffprev);
+
+  //! Sets the current boron concentration in ppm in the boron driver Openmc class
+  //! \param ppm is the current boron concentration in [ppm] after the Openmc run
+  void set_ppm(double ppm);
+
+  //! Sets the previous boron concentration in ppm in the boron driver Openmc class
+  //! \param ppm is the previous boron concentration in [ppm] in the previous Openmc run
+  void set_ppm_prev(double ppmprev);
+
+  //! Prints the current boron concentration in [ppm] and the current water density in
+  //! [g/cm^3]
+  void print_boron();
+
+  //! Estimates the boron concentration in ppm to find criticality condition
+  //! \param step is used to determine if an initial slope is needed
+  //! \return Boron concentration in [ppm]
+  double solveppm(int step);
+
+private:
+  double k_eff_;
+  double k_eff_prev;
+  double ppm_;
+  double ppm_prev_;
+  double H2O_dens_;
+};
+} // namespace enrico
+
+#endif // BORON_DRIVER_H

--- a/include/enrico/boron_driver.h
+++ b/include/enrico/boron_driver.h
@@ -49,8 +49,8 @@ public:
 
   // The current and previous values of the boron concentration
   // This is stored as parts-per-million on a number density basis
-  double ppm_prev_{0.};
-  double ppm_{0.};
+  double ppm_prev_{-1.};
+  double ppm_{-1.};
 
   // Denote if this driver is enabled or not
   bool is_enabled_{false};
@@ -58,7 +58,7 @@ public:
 private:
   double target_k_eff_{1.};
   double target_k_eff_tol_{0.001};
-  double epsilon_{1e-3};
+  double epsilon_{0.001};
   double target_k_eff_lo_{1. - 0.001};
   double target_k_eff_hi_{1. + 0.001};
 };

--- a/include/enrico/boron_driver.h
+++ b/include/enrico/boron_driver.h
@@ -32,9 +32,7 @@ public:
 
   //! Check convergence of the boron concentration
   //! for the current Picard iteration.
-  //! \param k_eff The latest estimate of k-eff
-  //! \param k_eff_prev The previous estimate of k-eff
-  bool is_converged(double k_eff, double k_eff_prev);
+  bool is_converged();
 
   //! The handles to the fluid cells
   std::vector<CellHandle> fluid_cell_handles_;
@@ -54,6 +52,8 @@ public:
 
 private:
   double target_k_eff_{1.};
+  //! Picard iteration convergence tolerance, defaults to 1e-3 if not set
+  double epsilon_{1e-3};
 };
 } // namespace enrico
 

--- a/include/enrico/boron_driver.h
+++ b/include/enrico/boron_driver.h
@@ -28,14 +28,13 @@ public:
   //! \param k_eff The latest estimate of k-eff
   //! \param k_eff_prev The previous estimate of k-eff
   //! \return Boron concentration in [ppm]
-  // TODO: Handle UncertainDouble [should move from neutronics to driver.h]
-  double solve_ppm(bool first_pass, double k_eff, double k_eff_prev);
+  double solve_ppm(bool first_pass, UncertainDouble& k_eff,
+                   UncertainDouble& k_eff_prev);
 
   //! Check convergence of the boron concentration
   //! for the current Picard iteration.
   //! \param k_eff The latest estimate of k-eff
-  // TODO: Handle UncertainDouble [should move from neutronics to driver.h]
-  bool is_converged(double k_eff);
+  bool is_converged(UncertainDouble& k_eff);
 
   //! The handles to the fluid cells
   std::vector<CellHandle> fluid_cell_handles_;
@@ -55,9 +54,10 @@ public:
 
 private:
   double target_k_eff_{1.};
-  double target_k_eff_tol_{0.01};
-  //! Picard iteration convergence tolerance on boron-10 ppm
+  double target_k_eff_tol_{0.001};
   double epsilon_{1e-3};
+  double target_k_eff_lo_{1. - 0.001};
+  double target_k_eff_hi_{1. + 0.001};
 };
 } // namespace enrico
 

--- a/include/enrico/boron_driver.h
+++ b/include/enrico/boron_driver.h
@@ -1,7 +1,7 @@
 //! \file boron_driver.h
 //! Base class for boron criticality search
-#ifndef BORON_DRIVER_H
-#define BORON_DRIVER_H
+#ifndef ENRICO_BORON_DRIVER_H
+#define ENRICO_BORON_DRIVER_H
 
 #include "enrico/driver.h"
 #include "enrico/heat_fluids_driver.h"
@@ -12,7 +12,7 @@
 namespace enrico {
 class BoronDriver : public Driver {
 public:
-  explicit BoronDriver(MPI_Comm comm, pugi::xml_node node);
+  BoronDriver(MPI_Comm comm, pugi::xml_node node);
 
   ~BoronDriver();
 
@@ -21,20 +21,20 @@ public:
   void set_fluid_cells(std::vector<CellHandle>& fluid_cell_handles);
 
   //! Prints the status of boron convergence
-  void print_boron();
+  void print_boron() const;
 
   //! Estimates the boron concentration in ppm to find criticality condition
   //! \param first_pass If this is the first iteration or not
   //! \param k_eff The latest estimate of k-eff
   //! \param k_eff_prev The previous estimate of k-eff
   //! \return Boron concentration in [ppm]
-  double solve_ppm(bool first_pass, UncertainDouble& k_eff,
-                   UncertainDouble& k_eff_prev);
+  double solve_ppm(bool first_pass, UncertainDouble k_eff,
+                   UncertainDouble k_eff_prev);
 
   //! Check convergence of the boron concentration
   //! for the current Picard iteration.
   //! \param k_eff The latest estimate of k-eff
-  bool is_converged(UncertainDouble& k_eff);
+  bool is_converged(UncertainDouble k_eff) const;
 
   //! The handles to the fluid cells
   std::vector<CellHandle> fluid_cell_handles_;
@@ -44,7 +44,7 @@ public:
   // "Isotopic compositions of the elements 2013(IUPAC Technical Report) ",
   // Pure. Appl. Chem. 88 (3), pp.293 - 306(2013).
   // This value is from the best available measurement column and is consistent
-  // with the data distriubted with OpenMC
+  // with the data distributed with OpenMC
   double B10_iso_abund_ {0.1982};
 
   // The current and previous values of the boron concentration
@@ -64,4 +64,4 @@ private:
 };
 } // namespace enrico
 
-#endif // BORON_DRIVER_H
+#endif // ENRICO_BORON_DRIVER_H

--- a/include/enrico/boron_driver.h
+++ b/include/enrico/boron_driver.h
@@ -28,11 +28,14 @@ public:
   //! \param k_eff The latest estimate of k-eff
   //! \param k_eff_prev The previous estimate of k-eff
   //! \return Boron concentration in [ppm]
+  // TODO: Handle UncertainDouble [should move from neutronics to driver.h]
   double solve_ppm(bool first_pass, double k_eff, double k_eff_prev);
 
   //! Check convergence of the boron concentration
   //! for the current Picard iteration.
-  bool is_converged();
+  //! \param k_eff The latest estimate of k-eff
+  // TODO: Handle UncertainDouble [should move from neutronics to driver.h]
+  bool is_converged(double k_eff);
 
   //! The handles to the fluid cells
   std::vector<CellHandle> fluid_cell_handles_;
@@ -52,7 +55,8 @@ public:
 
 private:
   double target_k_eff_{1.};
-  //! Picard iteration convergence tolerance, defaults to 1e-3 if not set
+  double target_k_eff_tol_{0.01};
+  //! Picard iteration convergence tolerance on boron-10 ppm
   double epsilon_{1e-3};
 };
 } // namespace enrico

--- a/include/enrico/boron_driver.h
+++ b/include/enrico/boron_driver.h
@@ -52,6 +52,9 @@ public:
   double ppm_prev_{0.};
   double ppm_{0.};
 
+  // Denote if this driver is enabled or not
+  bool is_enabled_{false};
+
 private:
   double target_k_eff_{1.};
   double target_k_eff_tol_{0.001};

--- a/include/enrico/cell_handle.h
+++ b/include/enrico/cell_handle.h
@@ -1,6 +1,8 @@
 #ifndef ENRICO_CELL_HANDLE_H
 #define ENRICO_CELL_HANDLE_H
 
+#include <cstddef>
+
 namespace enrico {
 using CellHandle = std::size_t;
 }

--- a/include/enrico/comm.h
+++ b/include/enrico/comm.h
@@ -14,7 +14,7 @@
 
 namespace enrico {
 
-//! Info and function wrappers for a specified MPI communictor.
+//! Info and function wrappers for a specified MPI communicator.
 class Comm {
 public:
   //! Default constructor

--- a/include/enrico/const.h
+++ b/include/enrico/const.h
@@ -6,6 +6,7 @@
 namespace enrico {
 
 constexpr double JOULE_PER_EV = 1.6021766208e-19;
+constexpr double CI_95 = 1.960;
 
 }
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -43,7 +43,7 @@ public:
   //! Execute the coupled driver
   virtual void execute();
 
-  //! Update the k-effective for the boron driver
+  //! Update the k-effective from the neutronics solver
   void update_k_effective();
 
   //! Update the boron concentration for the neutronics solver
@@ -104,15 +104,9 @@ public:
 
   int max_timesteps_; //!< Maximum number of time steps
 
-  double k_eff_; //!< k-effective
+  UncertainDouble k_eff_{0., 0.}; //!< k-effective
 
-  double k_eff_prev_;  //!< Previous k-effective
-
-  double boron_ppm_;  //!< Boron concentration
-
-  double boron_ppm_prev_; //!< Previous Boron concentration
-
-  double H2Odens_; //!< Density of water in Boronated water
+  UncertainDouble k_eff_prev_{0., 0.};  //!< Previous k-effective
 
   bool boron_search_{false};  //!< Flag to set if a Boron search is performed
 
@@ -171,6 +165,9 @@ private:
 
   //! Calculate and store local cell volumes in each heat/fluids rank
   void init_volume();
+
+  //! Initialize the input boron concentration from the model
+  void init_boron();
 
   //! Report how closely the neutron driver's volumes and the calculated local cell
   //! volumes (from init_volume()) match.  Raises no errors or warnings.

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -4,6 +4,7 @@
 #ifndef ENRICO_COUPLED_DRIVER_H
 #define ENRICO_COUPLED_DRIVER_H
 
+#include "enrico/boron_driver.h"
 #include "enrico/driver.h"
 #include "enrico/heat_fluids_driver.h"
 #include "enrico/neutronics_driver.h"
@@ -42,6 +43,12 @@ public:
   //! Execute the coupled driver
   virtual void execute();
 
+  //! Update the k-effective for the boron driver
+  void update_k_effective();
+
+  //! Update the boron concentration for the neutronics solver
+  void update_boron();
+
   //! Update the heat source for the thermal-hydraulics solver
   //!
   //! \param relax Apply relaxation to heat source before updating heat solver
@@ -73,6 +80,10 @@ public:
   //! \return reference to driver
   HeatFluidsDriver& get_heat_driver() const { return *heat_fluids_driver_; }
 
+  //! Get reference to boron search driver
+  //! \return reference to driver
+  BoronDriver& get_boron_driver() const { return *boron_driver_; }
+
   //! Get timestep iteration index
   //! \return timestep iteration index
   int get_timestep_index() const { return i_timestep_; }
@@ -92,6 +103,18 @@ public:
   double power_; //!< Power in [W]
 
   int max_timesteps_; //!< Maximum number of time steps
+
+  double k_eff_; //!< k-effective
+
+  double k_eff_prev_;  //!< Previous k-effective
+
+  double boron_ppm_;  //!< Boron concentration
+
+  double boron_ppm_prev_; //!< Previous Boron concentration
+
+  double H2Odens_; //!< Density of water in Boronated water
+
+  bool boron_search{false};  //!< Flag to set if a Boron search is performed
 
   int max_picard_iter_; //!< Maximum number of Picard iterations
 
@@ -211,6 +234,7 @@ private:
 
   std::unique_ptr<NeutronicsDriver> neutronics_driver_;  //!< The neutronics driver
   std::unique_ptr<HeatFluidsDriver> heat_fluids_driver_; //!< The heat-fluids driver
+  std::unique_ptr<BoronDriver> boron_driver_;            //!< The boron search driver
 
   //! 1 if local cell is in fluid, 0 if in solid. Set only on heat/fluids ranks.
   std::vector<int> cell_fluid_mask_;

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -114,7 +114,7 @@ public:
 
   double H2Odens_; //!< Density of water in Boronated water
 
-  bool boron_search{false};  //!< Flag to set if a Boron search is performed
+  bool boron_search_{false};  //!< Flag to set if a Boron search is performed
 
   int max_picard_iter_; //!< Maximum number of Picard iterations
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -211,12 +211,6 @@ private:
   //! List of ranks in this->comm_ that are in the heat/fluids subcomm
   std::vector<int> heat_ranks_;
 
-  //! List of ranks in this->comm_ that are in the neutronics subcomm
-  std::vector<int> neutronics_ranks_;
-
-  //! List of ranks in this->comm_ that are in the boron subcomm
-  std::vector<int> boron_ranks_;
-
   //! Local cell temperature at current Picard iteration. Set only on heat/fluids ranks.
   xt::xtensor<double, 1> cell_temperature_;
 

--- a/include/enrico/coupled_driver.h
+++ b/include/enrico/coupled_driver.h
@@ -205,11 +205,17 @@ private:
   //! The rank in comm_ that corresponds to the root of the heat comm
   int heat_root_ = MPI_PROC_NULL;
 
+  //! The rank in comm_ that corresponds to the root of the boron comm
+  int boron_root_ = MPI_PROC_NULL;
+
   //! List of ranks in this->comm_ that are in the heat/fluids subcomm
   std::vector<int> heat_ranks_;
 
   //! List of ranks in this->comm_ that are in the neutronics subcomm
   std::vector<int> neutronics_ranks_;
+
+  //! List of ranks in this->comm_ that are in the boron subcomm
+  std::vector<int> boron_ranks_;
 
   //! Local cell temperature at current Picard iteration. Set only on heat/fluids ranks.
   xt::xtensor<double, 1> cell_temperature_;

--- a/include/enrico/driver.h
+++ b/include/enrico/driver.h
@@ -70,6 +70,19 @@ public:
   int num_threads;
 };
 
+//! Contains the mean and standard deviation of an uncertain double float
+struct UncertainDouble {
+  // Constructors
+  UncertainDouble() {}
+  UncertainDouble(double nom, double sd)
+    : mean{nom}
+    , std_dev{sd}
+  {}
+
+  double mean{}; //!< Mean value
+  double std_dev{}; //!< Standard deviation
+};
+
 } // namespace enrico
 
 #endif // ENRICO_DRIVERS_H

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -29,6 +29,20 @@ public:
   //! \return Heat source in each material as [W/cm3]
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
 
+  //! Get the k-effective of a run
+  virtual double get_k_effective() const = 0;
+
+  //! Get the boron concentration
+  virtual double get_boron_ppm() const = 0;
+
+  //! Get the Boronated H2O density
+  virtual double get_H2O_dens() const = 0;
+
+  //! Set the Boron concentration in a cell
+  //! \param ppm Boric acid concentration in [ppm] !TODO: by wgt?
+  //! \param H2Odens water density in [g/cm^3]
+  virtual double set_boron_ppm(double ppm, double H2Odens) const = 0;
+
   //! Find cells corresponding to a vector of positions
   //! \param positions (x,y,z) coordinates to search for
   //! \return Handles to cells

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -41,7 +41,7 @@ public:
   //! Set the Boron concentration in a cell
   //! \param ppm Boric acid concentration in [ppm] !TODO: by wgt?
   //! \param H2Odens water density in [g/cm^3]
-  virtual double set_boron_ppm(double ppm, double H2Odens) const = 0;
+  virtual void set_boron_ppm(double ppm, double H2Odens) const = 0;
 
   //! Find cells corresponding to a vector of positions
   //! \param positions (x,y,z) coordinates to search for

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -33,13 +33,13 @@ public:
   virtual UncertainDouble get_k_effective() const = 0;
 
   //! Get the boron concentration from the model
-  virtual double get_boron_ppm(std::vector<CellHandle>& fluid_cell_handles) const = 0;
+  virtual double get_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles) const = 0;
 
   //! Set the Boron concentration in fluid-bearing cells
   //! \param fluid_cell_handles The CellHandle objects that contain fluids
   //! \param ppm Boric acid concentration in [ppm]
   //! \param B10_iso_abund The B-10 enrichment in unitless atom-fractions
-  virtual void set_boron_ppm(std::vector<CellHandle>& fluid_cell_handles,
+  virtual void set_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles,
                              double ppm, double B10_iso_abund) const = 0;
 
   //! Find cells corresponding to a vector of positions

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -15,6 +15,19 @@
 
 namespace enrico {
 
+//! Contains the mean and standard deviation of an uncertain double float
+struct UncertainDouble {
+  // Constructors
+  UncertainDouble() {}
+  UncertainDouble(double nom, double sd)
+    : mean{nom}
+    , std_dev{sd}
+  {}
+
+  double mean{}; //!< Mean value
+  double std_dev{}; //!< Standard deviation
+};
+
 //! Base class for driver that controls a neutronics solve
 class NeutronicsDriver : public Driver {
 public:
@@ -30,18 +43,17 @@ public:
   virtual xt::xtensor<double, 1> heat_source(double power) const = 0;
 
   //! Get the k-effective of a run
-  virtual double get_k_effective() const = 0;
+  virtual UncertainDouble get_k_effective() const = 0;
 
-  //! Get the boron concentration
-  virtual double get_boron_ppm() const = 0;
+  //! Get the boron concentration from the model
+  virtual double get_boron_ppm(std::vector<CellHandle>& fluid_cell_handles) const = 0;
 
-  //! Get the Boronated H2O density
-  virtual double get_H2O_dens() const = 0;
-
-  //! Set the Boron concentration in a cell
-  //! \param ppm Boric acid concentration in [ppm] !TODO: by wgt?
-  //! \param H2Odens water density in [g/cm^3]
-  virtual void set_boron_ppm(double ppm, double H2Odens) const = 0;
+  //! Set the Boron concentration in fluid-bearing cells
+  //! \param fluid_cell_handles The CellHandle objects that contain fluids
+  //! \param ppm Boric acid concentration in [ppm]
+  //! \param B10_iso_abund The B-10 enrichment in unitless atom-fractions
+  virtual void set_boron_ppm(std::vector<CellHandle>& fluid_cell_handles,
+                             double ppm, double B10_iso_abund) const = 0;
 
   //! Find cells corresponding to a vector of positions
   //! \param positions (x,y,z) coordinates to search for

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -15,19 +15,6 @@
 
 namespace enrico {
 
-//! Contains the mean and standard deviation of an uncertain double float
-struct UncertainDouble {
-  // Constructors
-  UncertainDouble() {}
-  UncertainDouble(double nom, double sd)
-    : mean{nom}
-    , std_dev{sd}
-  {}
-
-  double mean{}; //!< Mean value
-  double std_dev{}; //!< Standard deviation
-};
-
 //! Base class for driver that controls a neutronics solve
 class NeutronicsDriver : public Driver {
 public:

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -37,18 +37,17 @@ public:
   std::vector<CellHandle> find(const std::vector<Position>& position) override;
 
   //! Get the k-effective of a run
-  double get_k_effective() const override;
+  UncertainDouble get_k_effective() const override;
 
-  //! Get the boron concentration
-  double get_boron_ppm() const override;
+  //! Get the boron concentration from the model
+  double get_boron_ppm(std::vector<CellHandle>& fluid_cell_handles) const override;
 
-  //! Get the Boronated H2O density
-  double get_H2O_dens() const override;
-
-  //! Set the Boron concentration in a cell
-  //! \param ppm Boric acid concentration in [ppm] !TODO: by wgt?
-  //! \param H2Odens water density in [g/cm^3]
-  void set_boron_ppm(double ppm, double H2Odens) const override;
+  //! Set the Boron concentration in fluid-bearing cells
+  //! \param fluid_cell_handles The CellHandle objects that contain fluids
+  //! \param ppm Boric acid concentration in [ppm]
+  //! \param B10_iso_abund The B-10 enrichment in unitless atom-fractions
+  void set_boron_ppm(std::vector<CellHandle>& fluid_cell_handles,
+                     double ppm, double B10_iso_abund) const override;
 
   //! Set the density of the material in a cell
   //! \param cell Handle to a cell

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -36,6 +36,20 @@ public:
   //! \return Handles to cells
   std::vector<CellHandle> find(const std::vector<Position>& position) override;
 
+  //! Get the k-effective of a run
+  double get_k_effective() const override;
+
+  //! Get the boron concentration
+  double get_boron_ppm() const override;
+
+  //! Get the Boronated H2O density
+  double get_H2O_dens() const override;
+
+  //! Set the Boron concentration in a cell
+  //! \param ppm Boric acid concentration in [ppm] !TODO: by wgt?
+  //! \param H2Odens water density in [g/cm^3]
+  double set_boron_ppm(double ppm, double H2Odens) const override;
+
   //! Set the density of the material in a cell
   //! \param cell Handle to a cell
   //! \param rho Density in [g/cm^3]

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -48,7 +48,7 @@ public:
   //! Set the Boron concentration in a cell
   //! \param ppm Boric acid concentration in [ppm] !TODO: by wgt?
   //! \param H2Odens water density in [g/cm^3]
-  double set_boron_ppm(double ppm, double H2Odens) const override;
+  void set_boron_ppm(double ppm, double H2Odens) const override;
 
   //! Set the density of the material in a cell
   //! \param cell Handle to a cell

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -40,13 +40,13 @@ public:
   UncertainDouble get_k_effective() const override;
 
   //! Get the boron concentration from the model
-  double get_boron_ppm(std::vector<CellHandle>& fluid_cell_handles) const override;
+  double get_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles) const override;
 
   //! Set the Boron concentration in fluid-bearing cells
   //! \param fluid_cell_handles The CellHandle objects that contain fluids
   //! \param ppm Boric acid concentration in [ppm]
   //! \param B10_iso_abund The B-10 enrichment in unitless atom-fractions
-  void set_boron_ppm(std::vector<CellHandle>& fluid_cell_handles,
+  void set_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles,
                      double ppm, double B10_iso_abund) const override;
 
   //! Set the density of the material in a cell

--- a/include/enrico/shift_driver.h
+++ b/include/enrico/shift_driver.h
@@ -32,6 +32,23 @@ public:
   // get the heat source normalized to the given total power
   xt::xtensor<double, 1> heat_source(double power) const final;
 
+  //! Get the k-effective of a run
+  UncertainDouble get_k_effective() const override {
+    return UncertainDouble(0., 0.);
+  }
+
+  //! Get the boron concentration from the model
+  double get_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles) const override {
+    return 0.
+  };
+
+  //! Set the Boron concentration in fluid-bearing cells
+  //! \param fluid_cell_handles The CellHandle objects that contain fluids
+  //! \param ppm Boric acid concentration in [ppm]
+  //! \param B10_iso_abund The B-10 enrichment in unitless atom-fractions
+  void set_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles,
+                     double ppm, double B10_iso_abund) const override {};
+
   //! Find cells corresponding to a vector of positions
   //! \param positions (x,y,z) coordinates to search for
   //! \return Handles to cells

--- a/include/enrico/shift_driver.h
+++ b/include/enrico/shift_driver.h
@@ -39,15 +39,15 @@ public:
 
   //! Get the boron concentration from the model
   double get_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles) const override {
-    return 0.
-  };
+    return 0.;
+  }
 
   //! Set the Boron concentration in fluid-bearing cells
   //! \param fluid_cell_handles The CellHandle objects that contain fluids
   //! \param ppm Boric acid concentration in [ppm]
   //! \param B10_iso_abund The B-10 enrichment in unitless atom-fractions
   void set_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles,
-                     double ppm, double B10_iso_abund) const override {};
+                     double ppm, double B10_iso_abund) const override {}
 
   //! Find cells corresponding to a vector of positions
   //! \param positions (x,y,z) coordinates to search for

--- a/src/boron_driver.cpp
+++ b/src/boron_driver.cpp
@@ -1,55 +1,88 @@
 #include "enrico/boron_driver.h"
 
+#include <gsl/gsl>  // For Expects
+
 namespace enrico {
 
-BoronDriver::BoronDriver(MPI_Comm comm)
+BoronDriver::BoronDriver(MPI_Comm comm, pugi::xml_node node)
   : Driver(comm)
 {
   MPI_Barrier(MPI_COMM_WORLD);
-}
 
-void BoronDriver::set_k_effective(double keff, double keffprev)
-{
-  k_eff_prev = keffprev;
-  k_eff_ = keff;
-}
-
-void BoronDriver::set_ppm(double ppm)
-{
-  ppm_ = ppm;
-}
-
-void BoronDriver::set_ppm_prev(double ppmprev)
-{
-  ppm_prev_ = ppmprev;
-}
-
-void BoronDriver::set_H2O_density(double H2Odens)
-{
-  H2O_dens_ = H2Odens;
-}
-
-double BoronDriver::solveppm(int step)
-{
-  double m;
-  m = (ppm_ - ppm_prev_) / (k_eff_ - k_eff_prev);
-  if (step == 0) {
-    // Todo where is this from?
-    m = -15363.4365923065;
+  // Get the target k_eff to search for
+  if (node.child("target_keff")) {
+    target_k_eff_ = node.child("target_keff").text().as_double();
+  } else {
+    target_k_eff_ = 1.;
   }
-  ppm_ = (1.000 - k_eff_prev) * m + ppm_prev_;
+  Expects(target_k_eff_ > 0.);
+
+  // Get the B_10 isotopic abundance to use, if available
+  if (node.child("B10_enrichment")) {
+    B10_iso_abund_ = node.child("B10_enrichment").text().as_double();
+  }
+  Expects(B10_iso_abund_ > 0.);
+  Expects(B10_iso_abund_ <= 1.);
+}
+
+double BoronDriver::solve_ppm(bool first_pass, double k_eff, double k_eff_prev)
+{
+  // The estimation is performed using the Newton-Raphson method
+  double del_ppm_del_k;
+  double new_ppm;
+  if (first_pass) {
+    // Make a reasonable update so we can get two points to compute a derivative
+    if (k_eff > target_k_eff_) {
+      new_ppm = ppm_prev_ + 1000.;
+    } else if (k_eff < target_k_eff_) {
+      new_ppm = ppm_prev_ - 1000.;
+    } else {
+      // Then our most recent calculation was on target, so we keep it
+      // This should generally never be achieved by a realistic CE MC case due
+      // to the noise, but, it may be reached with simpler MG MC cases or
+      // deterministic solvers
+      new_ppm = ppm_prev_;
+    }
+
+  } else {
+    del_ppm_del_k = (ppm_ - ppm_prev_) / (k_eff - k_eff_prev);
+    new_ppm = (target_k_eff_ - k_eff) * del_ppm_del_k + ppm_;
+  }
+
+  // With noisy results we could have a negative guess for the ppm; this is
+  // clearly non-physical. Additionally the first guess value may be negative.
+  // For both negative cases a floor of 0 ppm is set
+  if (new_ppm < 0.) {
+    new_ppm = 0.;
+  }
+
+  ppm_prev_ = ppm_;
+  ppm_ = new_ppm;
 
   return ppm_;
+}
+
+bool BoronDriver::is_converged(double k_eff, double k_eff_prev) {
+  // TODO: fix, of course
+  return false;
+}
+
+void BoronDriver::set_fluid_cells(std::vector<CellHandle>& fluid_cell_handles) {
+  fluid_cell_handles_ = fluid_cell_handles;
 }
 
 void BoronDriver::print_boron()
 {
   std::ios_base::fmtflags old_flags(std::cout.flags());
   std::stringstream msg;
-  msg << "Boron Concentration [ppm]: " << ppm_prev_ << "\n";
-
-  msg << "          Water Density    [g/cm^3]: " << H2O_dens_;
+  msg << "\tUpdated Boron Concentration [ppm]: " << ppm_;
   comm_.message(msg.str());
+  msg.clear();
+  msg.str(std::string());
+  msg << "\t         B-10 Concentration [ppm]: " << B10_iso_abund_ * ppm_;
+  comm_.message(msg.str());
+  msg.clear();
+  msg.str(std::string());
 
   std::cout.flags(old_flags);
 }

--- a/src/boron_driver.cpp
+++ b/src/boron_driver.cpp
@@ -34,6 +34,7 @@ double BoronDriver::solveppm(int step)
   double m;
   m = (ppm_ - ppm_prev_) / (k_eff_ - k_eff_prev);
   if (step == 0) {
+    // Todo where is this from?
     m = -15363.4365923065;
   }
   ppm_ = (1.000 - k_eff_prev) * m + ppm_prev_;

--- a/src/boron_driver.cpp
+++ b/src/boron_driver.cpp
@@ -10,6 +10,13 @@ BoronDriver::BoronDriver(MPI_Comm comm, pugi::xml_node node)
 {
   MPI_Barrier(MPI_COMM_WORLD);
 
+  if (node.child("boron")) {
+    bool boron_flag = node.child("boron").text().as_bool();
+    if (boron_flag) {
+      is_enabled_ = true;
+    }
+  }
+
   // Get the target k_eff to search for
   if (node.child("target_keff")) {
     target_k_eff_ = node.child("target_keff").text().as_double();

--- a/src/boron_driver.cpp
+++ b/src/boron_driver.cpp
@@ -1,0 +1,60 @@
+#include "enrico/boron_driver.h"
+
+namespace enrico {
+
+BoronDriver::BoronDriver(MPI_Comm comm)
+  : Driver(comm)
+{
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+void BoronDriver::set_k_effective(double keff, double keffprev)
+{
+  k_eff_prev = keffprev;
+  k_eff_ = keff;
+}
+
+void BoronDriver::set_ppm(double ppm)
+{
+  ppm_ = ppm;
+}
+
+void BoronDriver::set_ppm_prev(double ppmprev)
+{
+  ppm_prev_ = ppmprev;
+}
+
+void BoronDriver::set_H2O_density(double H2Odens)
+{
+  H2O_dens_ = H2Odens;
+}
+
+double BoronDriver::solveppm(int step)
+{
+  double m;
+  m = (ppm_ - ppm_prev_) / (k_eff_ - k_eff_prev);
+  if (step == 0) {
+    m = -15363.4365923065;
+  }
+  ppm_ = (1.000 - k_eff_prev) * m + ppm_prev_;
+
+  return ppm_;
+}
+
+void BoronDriver::print_boron()
+{
+  std::ios_base::fmtflags old_flags(std::cout.flags());
+  std::stringstream msg;
+  msg << "Boron Concentration [ppm]: " << ppm_prev_ << "\n";
+
+  msg << "          Water Density    [g/cm^3]: " << H2O_dens_;
+  comm_.message(msg.str());
+
+  std::cout.flags(old_flags);
+}
+BoronDriver::~BoronDriver()
+{
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+} // namespace enrico

--- a/src/boron_driver.cpp
+++ b/src/boron_driver.cpp
@@ -116,7 +116,7 @@ bool BoronDriver::is_converged(UncertainDouble& k_eff) {
     k_eff_converged = false;
   }
 
-  msg << "  Boron change: " << std::fixed << std::setprecision(2)
+  msg << "  Boron change: " << std::fixed << std::setprecision(1)
       << B10_iso_abund_ * fabs(ppm_ - ppm_prev_);
   if (ppm_converged) {
     msg << " < ";

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -373,7 +373,7 @@ bool CoupledDriver::is_converged()
 
   auto& boron = get_boron_driver();
   if (boron.active()) {
-    boron_converged = boron.is_converged(k_eff_.mean, k_eff_prev_.mean);
+    boron_converged = boron.is_converged();
   } else {
     boron_converged = true;
   }

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -390,7 +390,7 @@ bool CoupledDriver::is_converged()
   msg << epsilon_ << " K";
   comm_.message(msg.str());
 
-  if (boron_search_) {
+  if (boron_search_ && i_timestep_ == 0) {
     auto& boron = get_boron_driver();
     boron_converged = boron.is_converged(k_eff_);
   } else {

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -358,7 +358,6 @@ double CoupledDriver::temperature_norm(Norm norm)
 
 bool CoupledDriver::is_converged()
 {
-  bool converged;
   bool heat_converged;
   bool boron_converged;
   double norm;
@@ -390,9 +389,7 @@ bool CoupledDriver::is_converged()
   }
   comm_.broadcast(boron_converged, heat_root_);
 
-  converged = heat_converged && boron_converged;
-
-  return converged;
+  return heat_converged && boron_converged;
 }
 
 void CoupledDriver::update_k_effective()

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -154,7 +154,7 @@ std::vector<CellHandle> OpenmcDriver::find(const std::vector<Position>& position
   return handles;
 }
 
-void OpenmcDriver::set_boron_ppm(std::vector<CellHandle>& fluid_cell_handles,
+void OpenmcDriver::set_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles,
                                  double ppm, double B10_iso_abund) const
 {
   // Step through all the fluid-filled cells we received from the heat solver
@@ -172,7 +172,7 @@ void OpenmcDriver::set_boron_ppm(std::vector<CellHandle>& fluid_cell_handles,
   //      assumed to not change the specific volume of the water (i.e.,
   //      the presence of boron increases the mass in density = mass / volume
   //      but not the volume term)
-  for (auto& cell : fluid_cell_handles) {
+  for (auto cell : fluid_cell_handles) {
     const auto& mat = this->cell_instance(cell).material();
     auto nucs = mat->nuclides();
     auto densities = mat->densities();
@@ -183,7 +183,7 @@ void OpenmcDriver::set_boron_ppm(std::vector<CellHandle>& fluid_cell_handles,
     double N_not_boron = 0.;
     for (int i = 0; i < nucs.size(); i++) {
       int nuc_index = nucs[i];
-      auto& nuclide = openmc::data::nuclides[nuc_index];
+      const auto& nuclide = openmc::data::nuclides[nuc_index];
 
       if (nuclide->Z_ != 5) {
         names.push_back(nuclide->name_);
@@ -266,18 +266,18 @@ const CellInstance& OpenmcDriver::cell_instance(CellHandle cell) const
   return cells_.at(cell_index_.at(cell));
 }
 
-double OpenmcDriver::get_boron_ppm(std::vector<CellHandle>& fluid_cell_handles) const
+double OpenmcDriver::get_boron_ppm(const std::vector<CellHandle>& fluid_cell_handles) const
 {
-  // This method gts the boron concentration from the initial conditions
+  // This method gets the boron concentration from the initial conditions.
   // In doing so, this method simply iterates through all fluid-bearing cells
   // and identifies the global ratio of boron atoms to non-boron atoms and
-  // converting this to a number-density based ppm.
+  // converts this to a number-density based ppm.
   // This method *could* take a single cell and extract the ppm from there, but
   // this method is slightly more robust against user input errors and the
-  // addiitonal execution is only incurred once.
+  // additional execution is only incurred once.
   double N_boron {0.};
   double N_not_boron {0.};
-  for (auto& cell : fluid_cell_handles) {
+  for (auto cell : fluid_cell_handles) {
     const auto& mat = this->cell_instance(cell).material();
     auto nucs = mat->nuclides();
     auto densities = mat->densities();
@@ -296,9 +296,7 @@ double OpenmcDriver::get_boron_ppm(std::vector<CellHandle>& fluid_cell_handles) 
     }
   }
 
-  auto ppm = N_boron / (N_boron + N_not_boron) * 1e6;
-
-  return ppm;
+  return N_boron / (N_boron + N_not_boron) * 1e6;;
 }
 
 void OpenmcDriver::init_step()

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -296,7 +296,7 @@ double OpenmcDriver::get_boron_ppm(const std::vector<CellHandle>& fluid_cell_han
     }
   }
 
-  return N_boron / (N_boron + N_not_boron) * 1e6;;
+  return N_boron / (N_boron + N_not_boron) * 1e6;
 }
 
 void OpenmcDriver::init_step()

--- a/tests/singlerod/make_openmc_model.py
+++ b/tests/singlerod/make_openmc_model.py
@@ -57,9 +57,9 @@ water.set_density('g/cm3', water_density)
 
 # Create cylinders
 radii = np.linspace(0., fuel_or, args.rings + 1)
-fuel_rings = [openmc.ZCylinder(R=r) for r in radii[1:]]
-clad_inner = openmc.ZCylinder(R=clad_ir)
-clad_outer = openmc.ZCylinder(R=clad_or)
+fuel_rings = [openmc.ZCylinder(r=r) for r in radii[1:]]
+clad_inner = openmc.ZCylinder(r=clad_ir)
+clad_outer = openmc.ZCylinder(r=clad_or)
 
 # Division for wedges
 xplane = openmc.XPlane(x0=0.0)
@@ -108,6 +108,10 @@ xmin = openmc.XPlane(x0=-pitch/2, boundary_type='periodic')
 xmax = openmc.XPlane(x0=pitch/2, boundary_type='periodic')
 ymin = openmc.YPlane(y0=-pitch/2, boundary_type='periodic')
 ymax = openmc.YPlane(y0=pitch/2, boundary_type='periodic')
+xmin.periodic_surface = xmax
+xmax.periodic_surface = xmin
+ymin.periodic_surface = ymax
+ymax.periodic_surface = ymin
 zmin = openmc.ZPlane(z0=0.0, boundary_type=boundary)
 zmax = openmc.ZPlane(z0=fuel_length, boundary_type=boundary)
 box = +xmin & -xmax & +ymin & -ymax & +zmin & -zmax

--- a/tests/singlerod/openmc_boron_heat_surrogate/enrico.xml
+++ b/tests/singlerod/openmc_boron_heat_surrogate/enrico.xml
@@ -5,7 +5,7 @@
     <procs_per_node>1</procs_per_node>
     <boron_search>true</boron_search>
     <target_keff>1.0</target_keff>
-    <target_keff_tolerance> 0.01 </target_keff_tolerance>
+    <target_keff_tolerance>0.01</target_keff_tolerance>
     <boron_epsilon>100</boron_epsilon>
   </neutronics>
   <heat_fluids>
@@ -31,6 +31,6 @@
     <power>820.0</power>
     <max_timesteps>2</max_timesteps>
     <max_picard_iter>10</max_picard_iter>
-    <epsilon> 50. </epsilon>
+    <epsilon>50.</epsilon>
   </coupling>
 </enrico>

--- a/tests/singlerod/openmc_boron_heat_surrogate/enrico.xml
+++ b/tests/singlerod/openmc_boron_heat_surrogate/enrico.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<enrico>
+  <neutronics>
+    <driver>openmc</driver>
+    <procs_per_node>1</procs_per_node>
+    <boron_search>true</boron_search>
+    <target_keff>1.0</target_keff>
+    <target_keff_tolerance> 0.01 </target_keff_tolerance>
+    <boron_epsilon>100</boron_epsilon>
+  </neutronics>
+  <heat_fluids>
+    <driver>surrogate</driver>
+    <pressure_bc>12.7553</pressure_bc>
+    <pellet_radius>0.406</pellet_radius>
+    <clad_inner_radius>0.414</clad_inner_radius>
+    <clad_outer_radius>0.475</clad_outer_radius>
+    <fuel_rings>6</fuel_rings>
+    <clad_rings>5</clad_rings>
+    <pin_pitch>1.26</pin_pitch>
+    <n_pins_x>1</n_pins_x>
+    <n_pins_y>1</n_pins_y>
+    <mass_flowrate>0.0525</mass_flowrate>
+    <inlet_temperature>500.0</inlet_temperature>
+    <z>0.0 0.5 1.0 1.5 2.0 2.5 3.0 3.5 4.0 4.5 5.0 5.5 6.0 6.5 7.0 7.5 8.0 8.5
+      9.0 9.5 10.0
+    </z>
+    <verbosity>high</verbosity>
+  </heat_fluids>
+  <coupling>
+    <communication>overlapping</communication>
+    <power>820.0</power>
+    <max_timesteps>2</max_timesteps>
+    <max_picard_iter>10</max_picard_iter>
+    <epsilon> 50. </epsilon>
+  </coupling>
+</enrico>

--- a/tests/singlerod/openmc_boron_heat_surrogate/geometry.xml
+++ b/tests/singlerod/openmc_boron_heat_surrogate/geometry.xml
@@ -1,0 +1,76 @@
+<?xml version='1.0' encoding='utf-8'?>
+<geometry>
+  <cell id="1" material="4 5 6 7 8 9 10 11 12 13" region="-1 8 9" universe="1" />
+  <cell id="2" material="14 15 16 17 18 19 20 21 22 23" region="1 -2 8 9" universe="1" />
+  <cell id="3" material="24 25 26 27 28 29 30 31 32 33" region="2 -3 8 9" universe="1" />
+  <cell id="4" material="34 35 36 37 38 39 40 41 42 43" region="3 -4 8 9" universe="1" />
+  <cell id="5" material="44 45 46 47 48 49 50 51 52 53" region="4 -5 8 9" universe="1" />
+  <cell id="6" material="void" region="5 -6 8 9" universe="1" />
+  <cell id="7" material="2" region="6 -7 8 9" universe="1" />
+  <cell id="8" material="54 55 56 57 58 59 60 61 62 63" region="7 8 9" universe="1" />
+  <cell id="9" material="64 65 66 67 68 69 70 71 72 73" region="-1 8 -9" universe="1" />
+  <cell id="10" material="74 75 76 77 78 79 80 81 82 83" region="1 -2 8 -9" universe="1" />
+  <cell id="11" material="84 85 86 87 88 89 90 91 92 93" region="2 -3 8 -9" universe="1" />
+  <cell id="12" material="94 95 96 97 98 99 100 101 102 103" region="3 -4 8 -9" universe="1" />
+  <cell id="13" material="104 105 106 107 108 109 110 111 112 113" region="4 -5 8 -9" universe="1" />
+  <cell id="14" material="void" region="5 -6 8 -9" universe="1" />
+  <cell id="15" material="2" region="6 -7 8 -9" universe="1" />
+  <cell id="16" material="114 115 116 117 118 119 120 121 122 123" region="7 8 -9" universe="1" />
+  <cell id="17" material="124 125 126 127 128 129 130 131 132 133" region="-1 -8 -9" universe="1" />
+  <cell id="18" material="134 135 136 137 138 139 140 141 142 143" region="1 -2 -8 -9" universe="1" />
+  <cell id="19" material="144 145 146 147 148 149 150 151 152 153" region="2 -3 -8 -9" universe="1" />
+  <cell id="20" material="154 155 156 157 158 159 160 161 162 163" region="3 -4 -8 -9" universe="1" />
+  <cell id="21" material="164 165 166 167 168 169 170 171 172 173" region="4 -5 -8 -9" universe="1" />
+  <cell id="22" material="void" region="5 -6 -8 -9" universe="1" />
+  <cell id="23" material="2" region="6 -7 -8 -9" universe="1" />
+  <cell id="24" material="174 175 176 177 178 179 180 181 182 183" region="7 -8 -9" universe="1" />
+  <cell id="25" material="184 185 186 187 188 189 190 191 192 193" region="-1 -8 9" universe="1" />
+  <cell id="26" material="194 195 196 197 198 199 200 201 202 203" region="1 -2 -8 9" universe="1" />
+  <cell id="27" material="204 205 206 207 208 209 210 211 212 213" region="2 -3 -8 9" universe="1" />
+  <cell id="28" material="214 215 216 217 218 219 220 221 222 223" region="3 -4 -8 9" universe="1" />
+  <cell id="29" material="224 225 226 227 228 229 230 231 232 233" region="4 -5 -8 9" universe="1" />
+  <cell id="30" material="void" region="5 -6 -8 9" universe="1" />
+  <cell id="31" material="2" region="6 -7 -8 9" universe="1" />
+  <cell id="32" material="234 235 236 237 238 239 240 241 242 243" region="7 -8 9" universe="1" />
+  <cell fill="2" id="33" region="10 -11 12 -13 14 -15" universe="3" />
+  <lattice id="2">
+    <pitch>1.26 1.26 1.0</pitch>
+    <dimension>1 1 10</dimension>
+    <lower_left>-0.63 -0.63 0.0</lower_left>
+    <universes>
+1
+
+1
+
+1
+
+1
+
+1
+
+1
+
+1
+
+1
+
+1
+
+1 </universes>
+  </lattice>
+  <surface coeffs="0.0 0.0 0.08120000000000001" id="1" type="z-cylinder" />
+  <surface coeffs="0.0 0.0 0.16240000000000002" id="2" type="z-cylinder" />
+  <surface coeffs="0.0 0.0 0.24360000000000004" id="3" type="z-cylinder" />
+  <surface coeffs="0.0 0.0 0.32480000000000003" id="4" type="z-cylinder" />
+  <surface coeffs="0.0 0.0 0.406" id="5" type="z-cylinder" />
+  <surface coeffs="0.0 0.0 0.414" id="6" type="z-cylinder" />
+  <surface coeffs="0.0 0.0 0.475" id="7" type="z-cylinder" />
+  <surface coeffs="0.0" id="8" type="x-plane" />
+  <surface coeffs="0.0" id="9" type="y-plane" />
+  <surface boundary="periodic" coeffs="-0.63" id="10" periodic_surface_id="11" type="x-plane" />
+  <surface boundary="periodic" coeffs="0.63" id="11" periodic_surface_id="10" type="x-plane" />
+  <surface boundary="periodic" coeffs="-0.63" id="12" periodic_surface_id="13" type="y-plane" />
+  <surface boundary="periodic" coeffs="0.63" id="13" periodic_surface_id="12" type="y-plane" />
+  <surface boundary="reflective" coeffs="0.0" id="14" type="z-plane" />
+  <surface boundary="reflective" coeffs="10.0" id="15" type="z-plane" />
+</geometry>

--- a/tests/singlerod/openmc_boron_heat_surrogate/materials.xml
+++ b/tests/singlerod/openmc_boron_heat_surrogate/materials.xml
@@ -1,0 +1,2094 @@
+<?xml version='1.0' encoding='utf-8'?>
+<materials>
+  <material id="2" name="M5" volume="0.04259135700288022">
+    <density units="g/cm3" value="6.494" />
+    <nuclide ao="0.508660425" name="Zr90" />
+    <nuclide ao="0.11092653" name="Zr91" />
+    <nuclide ao="0.169553475" name="Zr92" />
+    <nuclide ao="0.17182737" name="Zr94" />
+    <nuclide ao="0.0276822" name="Zr96" />
+    <nuclide ao="0.01" name="Nb93" />
+    <nuclide ao="0.0013494883500000002" name="O16" />
+    <nuclide ao="5.1165e-07" name="O17" />
+  </material>
+  <material depletable="true" id="4" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="5" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="6" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="7" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="8" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="9" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="10" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="11" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="12" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="13" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="14" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="15" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="16" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="17" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="18" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="19" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="20" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="21" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="22" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="23" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="24" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="25" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="26" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="27" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="28" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="29" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="30" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="31" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="32" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="33" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="34" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="35" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="36" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="37" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="38" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="39" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="40" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="41" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="42" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="43" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="44" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="45" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="46" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="47" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="48" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="49" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="50" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="51" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="52" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="53" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material id="54" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="55" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="56" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="57" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="58" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="59" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="60" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="61" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="62" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="63" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material depletable="true" id="64" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="65" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="66" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="67" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="68" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="69" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="70" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="71" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="72" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="73" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="74" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="75" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="76" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="77" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="78" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="79" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="80" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="81" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="82" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="83" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="84" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="85" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="86" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="87" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="88" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="89" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="90" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="91" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="92" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="93" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="94" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="95" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="96" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="97" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="98" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="99" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="100" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="101" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="102" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="103" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="104" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="105" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="106" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="107" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="108" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="109" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="110" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="111" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="112" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="113" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material id="114" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="115" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="116" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="117" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="118" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="119" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="120" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="121" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="122" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="123" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material depletable="true" id="124" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="125" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="126" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="127" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="128" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="129" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="130" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="131" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="132" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="133" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="134" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="135" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="136" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="137" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="138" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="139" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="140" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="141" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="142" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="143" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="144" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="145" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="146" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="147" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="148" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="149" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="150" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="151" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="152" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="153" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="154" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="155" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="156" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="157" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="158" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="159" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="160" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="161" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="162" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="163" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="164" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="165" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="166" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="167" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="168" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="169" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="170" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="171" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="172" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="173" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material id="174" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="175" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="176" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="177" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="178" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="179" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="180" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="181" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="182" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="183" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material depletable="true" id="184" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="185" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="186" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="187" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="188" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="189" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="190" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="191" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="192" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="193" name="UO2" volume="0.005178475666471272">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="194" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="195" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="196" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="197" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="198" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="199" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="200" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="201" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="202" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="203" name="UO2" volume="0.015535426999413817">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="204" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="205" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="206" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="207" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="208" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="209" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="210" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="211" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="212" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="213" name="UO2" volume="0.02589237833235637">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="214" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="215" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="216" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="217" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="218" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="219" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="220" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="221" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="222" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="223" name="UO2" volume="0.0362493296652989">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="224" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="225" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="226" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="227" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="228" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="229" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="230" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="231" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="232" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material depletable="true" id="233" name="UO2" volume="0.04660628099824143">
+    <density units="g/cm3" value="10.5312" />
+    <nuclide ao="0.000447810148570552" name="U234" />
+    <nuclide ao="0.05010104002438676" name="U235" />
+    <nuclide ao="0.9492216629994555" name="U238" />
+    <nuclide ao="0.00022948682758714957" name="U236" />
+    <nuclide ao="1.999242" name="O16" />
+    <nuclide ao="0.000758" name="O17" />
+  </material>
+  <material id="234" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="235" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="236" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="237" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="238" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="239" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="240" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="241" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="242" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+  <material id="243" name="Water" volume="0.21969453938345077">
+    <density units="g/cm3" value="0.7531966089109314" />
+    <nuclide ao="2.0" name="H1" />
+    <nuclide ao="0.999621" name="O16" />
+    <nuclide ao="0.000379" name="O17" />
+    <sab name="c_H_in_H2O" />
+  </material>
+</materials>

--- a/tests/singlerod/openmc_boron_heat_surrogate/settings.xml
+++ b/tests/singlerod/openmc_boron_heat_surrogate/settings.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<settings>
+  <run_mode>eigenvalue</run_mode>
+  <particles>1000</particles>
+  <batches>50</batches>
+  <inactive>10</inactive>
+  <source strength="1.0">
+    <space type="fission">
+      <parameters>-0.406 -0.406 0.0 0.406 0.406 10.0</parameters>
+    </space>
+  </source>
+  <temperature_default>523.15</temperature_default>
+  <temperature_method>interpolation</temperature_method>
+  <temperature_multipole>true</temperature_multipole>
+  <temperature_range>300.0 1500.0</temperature_range>
+</settings>


### PR DESCRIPTION
This PR completes the critical boron search driver implementation started by @mekiel-sudo.  This capability is added with a BoronDriver class that is an attribute of the CoupledDriver class. 

This capability performs the following actions:
1. Gathers user input from the ``<neutronics>`` block of enrico.xml:
  a. The capability is enabled with the boolean ``boron_search`` element.  
  b. When enabled, the following elements apply: ``initial_boron_ppm, target_keff, target_keff_tolerance, B10_enrichment, and boron_epsilon``.
2. The HeatDriver's knowledge of which cells are fluid bearing is communicated to the BoronDriver's processors. 
3. The initial boron conditions are set or determined, depending on the setting of the ``initial_boron_ppm`` parameter.
4. For each picard iteration the following is performed:
  a. Perform neutronics and heat calcs as usual
  b. Update the boron concentration with a simple first-order slope based method based on the last two Boron ppms and k-effs in order to predict the ppm to provide the ``target_keff``. 
  c. Check convergence of the heat solver as normal, and the boron driver by ensuring the boron ppm has changed less than the specified ``boron_epsilon`` input AND that k-eff is within the user-specified target k-eff and its tolerance. A 95% CI check is used to verify the MC-based k-eff and its stochastic uncertainty is within the target k-eff window.
5. If not converged, repeat back to step 4. If converged proceed to step 6
6. Update the time step and return to step 4, as usual. However, on subsequent timesteps no boron search is performed as Boron concentration is generally an initial condition outside of longer-term depletion-type calculations.

A single rod test with thermal feedback and a boron search is included in ``tests/singlerod/openmc_boron_heat_surrogate/``.  At this point, there is no automatic checking of results. This can change based on this PR review, but this seemed consistent with existing tests (though I may be misunderstanding!).

Finally, while this is noted in the manual, it should be noted here that the Boron ppm is stated on total Boron (vice B-10) ppm on a number density basis. Further, this implementation assumes the reactivity effect of the H/O in boric acid is small and therefore this Boron search only varies the Boron concentration and not the H/O with it.
