### PR TITLE
Use installed OpenMC if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ doc/build/
 *.rej
 *.bk*
 .cache/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ if (SCALE_FOUND)
 endif ()
 
 if (OpenMC_FOUND)
-    include_directories(${OpenMC_INCLUDE_DIR})
+    include_directories(${OpenMC_DIR}/../../../include)
 else ()
     include_directories(vendor/openmc/include)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,12 +107,25 @@ if (USE_NEKRS)
 endif ()
 
 # =============================================================================
+# Find and use OpenMC if already instealled
+# =============================================================================
+
+find_package(OpenMC QUIET)
+if (OpenMC_FOUND)
+    message(STATUS "Found OpenMC: ${OpenMC_DIR} (version ${OpenMC_VERSION})")
+else ()
+    message(STATUS "Did not find OpenMC, will use submodule instead")
+endif ()
+if (NOT OpenMC_FOUND)
+  add_subdirectory(vendor/openmc)
+endif ()
+
+# =============================================================================
 # Headers for all targets
 # =============================================================================
 include_directories(
         include/
         vendor/iapws/include
-        vendor/openmc/include
         vendor
         src/
         ${CMAKE_BINARY_DIR}
@@ -121,6 +134,12 @@ include_directories(
 if (SCALE_FOUND)
     include_directories(${SCALE_INCLUDE_DIRS})
     include_directories(${SCALE_TPL_INCLUDE_DIRS})
+endif ()
+
+if (OpenMC_FOUND)
+    include_directories(${OpenMC_INCLUDE_DIR})
+else ()
+    include_directories(vendor/openmc/include)
 endif ()
 
 # =============================================================================
@@ -133,7 +152,6 @@ elseif (USE_NEKRS)
     # TODO: An upstream fix to the NekRS CMakeLists should let us to omit this
     include_directories(vendor/nekRS/src/lib)
 endif ()
-add_subdirectory(vendor/openmc)
 
 # =============================================================================
 # IAPWS Correlations

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,6 @@ endif ()
 # =============================================================================
 # Find HDF5
 # =============================================================================
-
 find_package(HDF5 REQUIRED COMPONENTS HL C)
 
 # =============================================================================
@@ -205,11 +204,16 @@ add_library(libenrico
 set_target_properties(libenrico PROPERTIES OUTPUT_NAME enrico)
 set(LIBRARIES
     iapws
-    libopenmc
     xtensor
     heat_xfer
     pugixml
     gsl-lite)
+
+if (TARGET OpenMC::libopenmc)
+    list(APPEND LIBRARIES OpenMC::libopenmc)
+else ()
+    list(APPEND LIBRARIES libopenmc)
+endif ()
 
 target_compile_definitions(libenrico PRIVATE GSL_THROW_ON_CONTRACT_VIOLATION)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_INSTALL_RPATH
   "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_INSTALL_PREFIX}/lib")
 
-
 # =============================================================================
 # Nek Options
 # =============================================================================
@@ -107,7 +106,7 @@ if (USE_NEKRS)
 endif ()
 
 # =============================================================================
-# Find and use OpenMC if already instealled
+# Find and use OpenMC if already installed
 # =============================================================================
 
 find_package(OpenMC QUIET)
@@ -121,6 +120,12 @@ if (NOT OpenMC_FOUND)
 endif ()
 
 # =============================================================================
+# Find HDF5
+# =============================================================================
+
+find_package(HDF5 REQUIRED COMPONENTS HL C)
+
+# =============================================================================
 # Headers for all targets
 # =============================================================================
 include_directories(
@@ -129,7 +134,8 @@ include_directories(
         vendor
         src/
         ${CMAKE_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}/include)
+        ${CMAKE_BINARY_DIR}/include
+        ${HDF5_INCLUDE_DIRS})
 
 if (SCALE_FOUND)
     include_directories(${SCALE_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,8 +138,7 @@ include_directories(
         vendor
         src/
         ${CMAKE_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}/include
-        )
+        ${CMAKE_BINARY_DIR}/include)
 
 if (SCALE_FOUND)
     include_directories(${SCALE_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,14 @@ if (NOT OpenMC_FOUND)
 endif ()
 
 # =============================================================================
-# Find HDF5
+# set pugixml library as a variable
 # =============================================================================
-find_package(HDF5 REQUIRED COMPONENTS HL C)
+
+if (TARGET pugixml::pugixml)
+    set(LIBPUGIXML pugixml::pugixml)
+else ()
+    set(LIBPUGIXML pugixml)
+endif ()
 
 # =============================================================================
 # Headers for all targets
@@ -134,17 +139,11 @@ include_directories(
         src/
         ${CMAKE_BINARY_DIR}
         ${CMAKE_BINARY_DIR}/include
-        ${HDF5_INCLUDE_DIRS})
+        )
 
 if (SCALE_FOUND)
     include_directories(${SCALE_INCLUDE_DIRS})
     include_directories(${SCALE_TPL_INCLUDE_DIRS})
-endif ()
-
-if (OpenMC_FOUND)
-    include_directories(${OpenMC_DIR}/../../../include)
-else ()
-    include_directories(vendor/openmc/include)
 endif ()
 
 # =============================================================================
@@ -162,7 +161,7 @@ endif ()
 # IAPWS Correlations
 # =============================================================================
 add_library(iapws vendor/iapws/iapws.cpp)
-target_link_libraries(iapws PRIVATE gsl-lite)
+target_link_libraries(iapws PRIVATE gsl::gsl-lite-v1)
 target_compile_definitions(iapws PRIVATE GSL_THROW_ON_CONTRACT_VIOLATION)
 
 # =============================================================================
@@ -206,8 +205,8 @@ set(LIBRARIES
     iapws
     xtensor
     heat_xfer
-    pugixml
-    gsl-lite)
+    ${LIBPUGIXML}
+    gsl::gsl-lite-v1)
 
 if (TARGET OpenMC::libopenmc)
     list(APPEND LIBRARIES OpenMC::libopenmc)
@@ -282,7 +281,7 @@ target_include_directories(Catch INTERFACE vendor/catch/single_include/catch2)
 add_executable(unittests
   tests/unit/catch.cpp
   tests/unit/test_surrogate_th.cpp)
-target_link_libraries(unittests PUBLIC Catch pugixml libenrico)
+target_link_libraries(unittests PUBLIC Catch ${LIBPUGIXML} libenrico)
 set_target_properties(unittests PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
 
 #################################################################################

--- a/include/enrico/neutronics_driver.h
+++ b/include/enrico/neutronics_driver.h
@@ -8,7 +8,7 @@
 #include "enrico/geom.h"
 #include "enrico/mpi_types.h"
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <xtensor/xtensor.hpp>
 
 #include <vector>

--- a/include/enrico/openmc_driver.h
+++ b/include/enrico/openmc_driver.h
@@ -10,7 +10,7 @@
 #include "openmc/cell.h"
 #include "openmc/tallies/filter_cell_instance.h"
 #include "openmc/tallies/tally.h"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <mpi.h>
 
 #include <unordered_map>

--- a/include/enrico/surrogate_heat_driver.h
+++ b/include/enrico/surrogate_heat_driver.h
@@ -6,7 +6,7 @@
 #include "enrico/geom.h"
 #include "enrico/heat_fluids_driver.h"
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <mpi.h>
 #include <pugixml.hpp>
 #include <xtensor/xtensor.hpp>

--- a/src/comm_split.cpp
+++ b/src/comm_split.cpp
@@ -1,5 +1,5 @@
 #include "enrico/comm_split.h"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 namespace enrico {
 

--- a/src/coupled_driver.cpp
+++ b/src/coupled_driver.cpp
@@ -18,7 +18,7 @@
 #endif
 #include "enrico/surrogate_heat_driver.h"
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <xtensor/xbuilder.hpp> // for empty
 #include <xtensor/xnorm.hpp>    // for norm_l1, norm_l2, norm_linf
 

--- a/src/heat_fluids_driver.cpp
+++ b/src/heat_fluids_driver.cpp
@@ -1,6 +1,6 @@
 #include "enrico/heat_fluids_driver.h"
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 #include <pugixml.hpp>
 #include <xtensor/xadapt.hpp>
 

--- a/src/nek5000_driver.cpp
+++ b/src/nek5000_driver.cpp
@@ -1,7 +1,7 @@
 #include "enrico/nek5000_driver.h"
 
 #include "enrico/error.h"
-#include "gsl/gsl"
+#include "gsl/gsl-lite.hpp"
 #include "iapws/iapws.h"
 #include "nek5000/core/nek_interface.h"
 #include "xtensor/xadapt.hpp"

--- a/src/openmc_driver.cpp
+++ b/src/openmc_driver.cpp
@@ -13,7 +13,7 @@
 #include "xtensor/xadapt.hpp"
 #include "xtensor/xarray.hpp"
 #include "xtensor/xview.hpp"
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include <string>
 #include <unordered_map>

--- a/src/shift_driver.cpp
+++ b/src/shift_driver.cpp
@@ -1,6 +1,6 @@
 #include "enrico/shift_driver.h"
 
-#include <gsl/gsl> // for Expects
+#include <gsl/gsl-lite.hpp> // for Expects
 
 #include "Omnibus/driver/Sequence_Shift.hh" // for Sequence_Shift
 #include "Shift/mc_tallies/Cell_Union_Tally.hh"

--- a/vendor/iapws/iapws.cpp
+++ b/vendor/iapws/iapws.cpp
@@ -1,6 +1,6 @@
 #include "iapws/iapws.h"
 
-#include <gsl/gsl>
+#include <gsl/gsl-lite.hpp>
 
 #include <cmath>
 


### PR DESCRIPTION
The goal of this change is to find OpenMC if it is already installed and use that instead of the submodule. Updates also include a change to the `gsl` headers that are included throughout the code. That is both a best practice now and also necessary for this change to work.

I believe this should address #152.