### PR TITLE
ENRICO nekRS_driver Update to Support nekRS v22

### DIFF
--- a/src/nekrs_driver.cpp
+++ b/src/nekrs_driver.cpp
@@ -64,18 +64,10 @@ NekRSDriver::NekRSDriver(MPI_Comm comm, pugi::xml_node node)
     MPI_Allreduce(
       &n, &n_global_elem_, 1, get_mpi_type<std::size_t>(), MPI_SUM, comm_.comm);
 
-    std::vector<double> xLoc(mesh->Nlocal);
-    std::vector<double> yLoc(mesh->Nlocal);
-    std::vector<double> zLoc(mesh->Nlocal);
-  
-    mesh->o_x.copyTo(xLoc.data(), mesh->Nlocal * sizeof(dfloat));
-    mesh->o_y.copyTo(yLoc.data(), mesh->Nlocal * sizeof(dfloat));
-    mesh->o_z.copyTo(zLoc.data(), mesh->Nlocal * sizeof(dfloat));
-  
-    x_ = xLoc.data();
-    y_ = yLoc.data();
-    z_ = zLoc.data();
-
+    x_ = mesh->x;
+    y_ = mesh->y;
+    z_ = mesh->z;
+ 
     element_info_ = mesh->elementInfo;
 
     // rho energy is field 1 (0-based) of rho

--- a/src/nekrs_driver.cpp
+++ b/src/nekrs_driver.cpp
@@ -56,14 +56,13 @@ NekRSDriver::NekRSDriver(MPI_Comm comm, pugi::xml_node node)
             "ENRICO must be run with a CHT simulation.");
 
     mesh_t *mesh = nrs_ptr_->cds->mesh[0];
-    // Local and global element counts
     n_local_elem_ = mesh->Nelements;
+    poly_deg_ = mesh->N;
+    n_gll_ = mesh->Np;
+
     std::size_t n = n_local_elem_;
     MPI_Allreduce(
       &n, &n_global_elem_, 1, get_mpi_type<std::size_t>(), MPI_SUM, comm_.comm);
-
-    poly_deg_ = mesh->N;
-    n_gll_ = mesh->Np;
 
     std::vector<double> xLoc(mesh->Nlocal);
     std::vector<double> yLoc(mesh->Nlocal);
@@ -84,7 +83,7 @@ NekRSDriver::NekRSDriver(MPI_Comm comm, pugi::xml_node node)
     temperature_ = nrs_ptr_->cds->S;
 
     // Construct lumped mass matrix from vgeo
-    mass_matrix_.resize(n_local_elem_ * n_gll_);
+    mass_matrix_.resize(mesh->Nelements * mesh->Np);
     for(dlong e = 0; e < mesh->Nelements; ++e)
       for(int n = 0; n < mesh->Np; ++n)
         mass_matrix_[e * mesh->Np + n] = mesh->vgeo[e * mesh->Np * mesh->Nvgeo + JWID * mesh->Np + n];


### PR DESCRIPTION
This MR contains changes to `nekrs_driver.cpp` to make ENRICO compatible with nekRS v22. The updated ENRICO has been tested to run successfully on both local CPU clusters and ORNL Summit. 

**Caveats**: 
 - The current nekRS driver also requires necessary bug fixes within the nekRS source, which has not been merged in the latest nekRS repo yet. A follow-up update will be committed once the [nekRS github repo](https://github.com/Nek5000/nekRS) is updated 
 - The updated ENRICO not necessarily shows a performance boost for small-scale simulations (e.g., a single rod test case). Larger scale simulations are required to see the benefits of performance enhancement from nekRS CFD solver. 