### PR TITLE
Update data directory for OpenMC cross sections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Environment Variables
         run: |
-          echo "OPENMC_CROSS_SECTIONS=$HOME/endfb71_hdf5/cross_sections.xml" >> $GITHUB_ENV
+          echo "OPENMC_CROSS_SECTIONS=$HOME/endfb-vii.1-hdf5/cross_sections.xml" >> $GITHUB_ENV
 
       - name: Apt dependencies
         shell: bash

--- a/ci/download_xs.sh
+++ b/ci/download_xs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ ! -e $HOME/endfb71_hdf5/cross_sections.xml ]; then
+if [ ! -e $HOME/endfb-vii.1-hdf5/cross_sections.xml ]; then
   cd $HOME
   wget https://anl.box.com/shared/static/9igk353zpy8fn9ttvtrqgzvw1vtejoz6.xz -O - | tar -xvJ
 fi


### PR DESCRIPTION
I recently updated the cross sections libraries for OpenMC due to a bug (described in full [here](https://github.com/openmc-dev/data/issues/77)). Along with that update, the directory name in the tarball changed, so this PR simply updates the directory name used in the tests that require running OpenMC.