### PR TITLE
Change CI to use OpenMPI instead of MPICH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ env:
   MPI_DIR: /usr
   OMP_NUM_THREADS: 2
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  MPICH_FC: gfortran
 
 jobs:
   main:
@@ -43,9 +42,8 @@ jobs:
         run: |
           sudo apt -y update
           sudo apt install -y gfortran \
-                              mpich \
-                              libmpich-dev \
-                              libhdf5-mpich-dev \
+                              libopenmpi-dev \
+                              libhdf5-openmpi-dev \
                               liblapack-dev
       - name: before_install
         shell: bash


### PR DESCRIPTION
As soon as we fixed one CI problem, another one [popped up](https://github.com/enrico-dev/enrico/actions/runs/3651371451). GitHub actions recently changed the default ubuntu distro to 22.04 from 20.04, which appears to have caused problems when linking against Nek5000. As far as I can tell, this appears to be related to the use of MPICH, which on Ubuntu 22.04 adds several extra compile flags for link-time optimization. Switching to OpenMPI fixes the problem for me locally :crossed_fingers: 